### PR TITLE
Make the length of Product{Tuple{}} zero

### DIFF
--- a/src/IterTools.jl
+++ b/src/IterTools.jl
@@ -203,7 +203,8 @@ end
 iteratorsize{T<:Product}(::Type{T}) = SizeUnknown()
 
 eltype{T}(::Type{Product{T}}) = Tuple{map(eltype, T.parameters)...}
-length(p::Product) = mapreduce(length, *, 1, p.xss)
+length(p::Product{Tuple{}}) = 0
+length(p::Product) = prod(length, p.xss)
 
 """
     product(xs...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -191,8 +191,7 @@ p0 = product(x1, x2)
 p1 = product()
 
 @test eltype(p1) == Tuple{}
-@test length(p1) == 1
-@test collect(p1) == [()]
+@test length(p1) == 0
 
 # distinct
 # --------


### PR DESCRIPTION
This puts it in line with lengths of products of empty collections.