### PR TITLE
Require 0.6 + some testing stuff

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ os:
     - linux
     - osx
 julia:
-    - 0.5
     - 0.6
     - nightly
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
 language: julia
 os:
-    - linux
-    - osx
+  - linux
 julia:
-    - 0.6
-    - nightly
+  - 0.6
+  - nightly
+matrix:
+  allow_failures:
+    - julia: nightly
 notifications:
   email: false
 after_script:
-    - julia -e 'cd(Pkg.dir("IterTools")); Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'
+  - julia -e 'cd(Pkg.dir("IterTools")); Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 IterTools.jl is licensed under the MIT License:
 
-> Copyright (c) 2012-2016: Daniel Jones, Stefan Karpinski, Simon Kornblith,
+> Copyright (c) 2012-2017: Daniel Jones, Stefan Karpinski, Simon Kornblith,
 > Kevin Squire, Jeff Bezanson, Tim Holy, Jonathan Malmaud, Eric Davies, and
 > other contributors.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # IterTools.jl
 
-[![IterTools](http://pkg.julialang.org/badges/IterTools_0.4.svg)](http://pkg.julialang.org/?pkg=IterTools&ver=0.4)
-[![IterTools](http://pkg.julialang.org/badges/IterTools_0.5.svg)](http://pkg.julialang.org/?pkg=IterTools&ver=0.5)
+[![IterTools](http://pkg.julialang.org/badges/IterTools_0.6.svg)](http://pkg.julialang.org/?pkg=IterTools&ver=0.6)
 
 [![Build Status](https://travis-ci.org/JuliaCollections/IterTools.jl.svg?branch=master)](https://travis-ci.org/JuliaCollections/IterTools.jl)
 [![Coverage Status](https://codecov.io/gh/JuliaCollections/IterTools.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/JuliaCollections/IterTools.jl)

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,1 @@
-julia 0.5
+julia 0.6

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -12,8 +12,8 @@ makedocs(
 deploydocs(
     repo = "github.com/JuliaCollections/IterTools.jl.git",
     target = "build",
-    julia  = "0.5",
-    osname = "osx",
+    julia  = "0.6",
+    osname = "linux",
     deps = nothing,
     make = nothing
 )

--- a/src/IterTools.jl
+++ b/src/IterTools.jl
@@ -2,10 +2,7 @@ __precompile__()
 
 module IterTools
 
-# gets around deprecation warnings in v0.6
-if isdefined(Base, :Iterators)
-    import Base.Iterators: drop, countfrom, cycle, take, repeated
-end
+import Base.Iterators: drop, take
 
 import Base: start, next, done, eltype, length, size
 import Base: iteratorsize, IteratorSize, SizeUnknown, IsInfinite, HasLength, HasShape
@@ -39,8 +36,8 @@ promote_iteratoreltype(::HasEltype, ::HasEltype) = HasEltype()
 promote_iteratoreltype(::IteratorEltype, ::IteratorEltype) = EltypeUnknown()
 
 # return the size for methods depending on the longest iterator
-longest{T<:IteratorSize}(::T, ::T) = T()
-function longest{T<:IteratorSize, S<:IteratorSize}(::S, ::T)
+longest(::T, ::T) where {T<:IteratorSize} = T()
+function longest(::S, ::T) where {T<:IteratorSize, S<:IteratorSize}
     longest(T(), S())
 end
 longest(::HasShape, ::HasShape) = HasLength()
@@ -52,8 +49,8 @@ longest(::IsInfinite, ::HasLength) = IsInfinite()
 longest(::IsInfinite, ::SizeUnknown) = IsInfinite()
 
 # return the size for methods depending on the shortest iterator
-shortest{T<:IteratorSize}(::T, ::T) = T()
-function shortest{T<:IteratorSize, S<:IteratorSize}(::S, ::T)
+shortest(::T, ::T) where {T<:IteratorSize} = T()
+function shortest(::S, ::T) where {T<:IteratorSize, S<:IteratorSize}
     shortest(T(), S())
 end
 shortest(::HasShape, ::HasShape) = HasLength()
@@ -69,13 +66,13 @@ include("tuple_types.jl")
 # Iterate through the first n elements, throwing an exception if
 # fewer than n items ar encountered.
 
-immutable TakeStrict{I}
+struct TakeStrict{I}
     xs::I
     n::Int
 end
-iteratorsize{T<:TakeStrict}(::Type{T}) = HasLength()
-iteratoreltype{I}(::Type{TakeStrict{I}}) = iteratoreltype(I)
-eltype{I}(::Type{TakeStrict{I}}) = eltype(I)
+iteratorsize(::Type{<:TakeStrict}) = HasLength()
+iteratoreltype(::Type{TakeStrict{I}}) where {I} = iteratoreltype(I)
+eltype(::Type{TakeStrict{I}}) where {I} = eltype(I)
 
 """
     takestrict(xs, n::Int)
@@ -122,11 +119,11 @@ end
 
 # Repeat a function application n (or infinitely many) times.
 
-immutable RepeatCall{F<:Base.Callable}
+struct RepeatCall{F<:Base.Callable}
     f::F
     n::Int
 end
-iteratorsize{T<:RepeatCall}(::Type{T}) = HasLength()
+iteratorsize(::Type{<:RepeatCall}) = HasLength()
 
 length(it::RepeatCall) = it.n
 
@@ -154,10 +151,10 @@ start(it::RepeatCall) = it.n
 next(it::RepeatCall, state) = (it.f(), state - 1)
 done(it::RepeatCall, state) = state <= 0
 
-immutable RepeatCallForever{F<:Base.Callable}
+struct RepeatCallForever{F<:Base.Callable}
     f::F
 end
-iteratorsize{T<:RepeatCallForever}(::Type{T}) = IsInfinite()
+iteratorsize(::Type{<:RepeatCallForever}) = IsInfinite()
 
 repeatedly(f) = RepeatCallForever(f)
 
@@ -167,7 +164,7 @@ done(it::RepeatCallForever, state) = false
 
 
 # Concatenate the output of n iterators
-immutable Chain{T<:Tuple}
+struct Chain{T<:Tuple}
     xss::T
 end
 
@@ -194,11 +191,13 @@ chain(xss...) = Chain(xss)
 
 length(it::Chain{Tuple{}}) = 0
 length(it::Chain) = sum(length, it.xss)
-function iteratoreltype{T}(::Type{Chain{T}})
+function iteratoreltype(::Type{Chain{T}}) where T
     mapreduce_tt(iteratoreltype, promote_iteratoreltype, HasEltype(), T)
 end
-iteratorsize{T}(::Type{Chain{T}}) = mapreduce_tt(iteratorsize, longest, HasLength(), T)
-eltype{T}(::Type{Chain{T}}) = mapreduce_tt(eltype, typejoin, Union{}, T)
+function iteratorsize(::Type{Chain{T}}) where T
+    mapreduce_tt(iteratorsize, longest, HasLength(), T)
+end
+eltype(::Type{Chain{T}}) where {T} = mapreduce_tt(eltype, typejoin, Union{}, T)
 
 function start(it::Chain)
     i = 1
@@ -231,12 +230,14 @@ done(it::Chain, state) = state[1] > length(it.xss)
 
 # Cartesian product as a sequence of tuples
 
-immutable Product{T<:Tuple}
+struct Product{T<:Tuple}
     xss::T
 end
 
-iteratorsize{T}(::Type{Product{T}}) = mapreduce_tt(iteratorsize, longest, HasLength(), T)
-eltype{T}(::Type{Product{T}}) = map_tt_t(eltype, T)
+function iteratorsize(::Type{Product{T}}) where T
+    mapreduce_tt(iteratorsize, longest, HasLength(), T)
+end
+eltype(::Type{Product{T}}) where {T} = map_tt_t(eltype, T)
 length(p::Product{Tuple{}}) = 0
 length(p::Product) = prod(length, p.xss)
 
@@ -297,7 +298,7 @@ done(it::Product, state) = state[2] === nothing
 
 # Filter out reccuring elements.
 
-immutable Distinct{I, J}
+struct Distinct{I, J}
     xs::I
 
     # Map elements to the index at which it was first seen, so given an iterator
@@ -305,9 +306,9 @@ immutable Distinct{I, J}
     seen::Dict{J, Int}
 end
 
-iteratorsize{T<:Distinct}(::Type{T}) = SizeUnknown()
+iteratorsize(::Type{<:Distinct}) = SizeUnknown()
 
-eltype{I, J}(::Type{Distinct{I, J}}) = J
+eltype(::Type{Distinct{I, J}}) where {I, J} = J
 
 """
     distinct(xs)
@@ -324,7 +325,7 @@ i = 4
 i = 3
 ```
 """
-distinct{I}(xs::I) = Distinct{I, eltype(xs)}(xs, Dict{eltype(xs), Int}())
+distinct(xs::I) where {I} = Distinct{I, eltype(xs)}(xs, Dict{eltype(xs), Int}())
 # TODO: only use eltype when I has iteratoreltype?
 function start(it::Distinct)
     start(it.xs), 1
@@ -357,13 +358,13 @@ done(it::Distinct, state) = done(it.xs, state[1])
 #   partition(count(1), 2, 1) = (1,2), (2,3), (3,4) ...
 #   partition(count(1), 2, 3) = (1,2), (4,5), (7,8) ...
 
-immutable Partition{I, N}
+struct Partition{I, N}
     xs::I
     step::Int
 end
-iteratorsize{T<:Partition}(::Type{T}) = SizeUnknown()
+iteratorsize(::Type{<:Partition}) = SizeUnknown()
 
-eltype{I, N}(::Type{Partition{I, N}}) = NTuple{N, eltype(I)}
+eltype(::Type{Partition{I, N}}) where {I, N} = NTuple{N, eltype(I)}
 
 """
     partition(xs, n, [step])
@@ -405,11 +406,11 @@ i = (4,5)
 i = (7,8)
 ```
 """
-function partition{I}(xs::I, n::Int)
+function partition(xs::I, n::Int) where I
     Partition{I, n}(xs, n)
 end
 
-function partition{I}(xs::I, n::Int, step::Int)
+function partition(xs::I, n::Int, step::Int) where I
     if step < 1
         throw(ArgumentError("Partition step must be at least 1."))
     end
@@ -417,7 +418,7 @@ function partition{I}(xs::I, n::Int, step::Int)
     Partition{I, n}(xs, step)
 end
 
-function start{I, N}(it::Partition{I, N})
+function start(it::Partition{I, N}) where {I, N}
     p = Vector{eltype(I)}(N)
     s = start(it.xs)
     for i in 1:(N - 1)
@@ -429,7 +430,7 @@ function start{I, N}(it::Partition{I, N})
     (s, p)
 end
 
-function next{I, N}(it::Partition{I, N}, state)
+function next(it::Partition{I, N}, state) where {I, N}
     (s, p0) = state
     (x, s) = next(it.xs, s)
     ans = p0; ans[end] = x
@@ -472,14 +473,14 @@ done(it::Partition, state) = done(it.xs, state[1])
 #       ["face", "foo"]
 #       ["bar", "book", "baz"]
 #       ["zzz"]
-immutable GroupBy{I, F<:Base.Callable}
+struct GroupBy{I, F<:Base.Callable}
     keyfunc::F
     xs::I
 end
-iteratorsize{T<:GroupBy}(::Type{T}) = SizeUnknown()
+iteratorsize(::Type{<:GroupBy}) = SizeUnknown()
 
 # eltype{I}(it::GroupBy{I}) = I
-eltype{I, F}(::Type{GroupBy{I, F}}) = Vector{eltype(I)}
+eltype(::Type{GroupBy{I, F}}) where {I, F} = Vector{eltype(I)}
 
 """
     groupby(f, xs)
@@ -506,7 +507,7 @@ function start(it::GroupBy)
     return (s, (prev_key, prev_value))
 end
 
-function next{I}(it::GroupBy{I}, state)
+function next(it::GroupBy{I}, state) where I
     (s, (prev_key, prev_value)) = state
     values = Vector{eltype(I)}(0)
     # We had a left over value from the last time the key changed.
@@ -540,13 +541,15 @@ end
 # is done when any of the input iterators have been exhausted.
 # E.g.,
 #   imap(+, count(), [1, 2, 3]) = 1, 3, 5 ...
-immutable IMap{F<:Base.Callable, T<:Tuple}
+struct IMap{F<:Base.Callable, T<:Tuple}
     mapfunc::F
     xs::T
 end
 
-iteratorsize{F, T}(::Type{IMap{F, T}}) = mapreduce_tt(iteratorsize, shortest, HasLength(), T)
-iteratoreltype{I<:IMap}(::Type{I}) = EltypeUnknown()
+function iteratorsize(::Type{IMap{F, T}}) where {F, T}
+    mapreduce_tt(iteratorsize, shortest, HasLength(), T)
+end
+iteratoreltype(::Type{<:IMap}) = EltypeUnknown()
 length(it::IMap) = minimum(length(x) for x in it.xs if has_length(x))
 
 """
@@ -586,12 +589,12 @@ end
 
 # Iterate over all subsets of a collection
 
-immutable Subsets{C}
+struct Subsets{C}
     xs::C
 end
-iteratorsize{C}(::Type{Subsets{C}}) = longest(HasLength(), iteratorsize(C))
+iteratorsize(::Type{Subsets{C}}) where {C} = longest(HasLength(), iteratorsize(C))
 
-eltype{C}(::Type{Subsets{C}}) = Vector{eltype(C)}
+eltype(::Type{Subsets{C}}) where {C} = Vector{eltype(C)}
 length(it::Subsets) = 1 << length(it.xs)
 
 """
@@ -657,26 +660,28 @@ end
 
 # Iterate over all subsets of a collection with a given size
 
-immutable Binomial{T}
+struct Binomial{T}
     xs::Vector{T}
     n::Int64
     k::Int64
 end
-Binomial{T}(xs::AbstractVector{T}, n::Integer, k::Integer) = Binomial{T}(xs, n, k)
+Binomial(xs::AbstractVector{T}, n::Integer, k::Integer) where {T} = Binomial{T}(xs, n, k)
 
-iteratorsize{T<:Binomial}(::Type{T}) = HasLength()
+iteratorsize(::Type{<:Binomial}) = HasLength()
 
-eltype{T}(::Type{Binomial{T}}) = Vector{T}
+eltype(::Type{Binomial{T}}) where {T} = Vector{T}
 length(it::Binomial) = binomial(it.n,it.k)
 
 subsets(xs,k) = Binomial(xs,length(xs),k)
 
-type BinomialIterState
+mutable struct BinomialIterState
     idx::Vector{Int64}
     done::Bool
 end
 
-start(it::Binomial) = BinomialIterState(collect(Int64, 1:it.k), (it.k > it.n) ? true : false)
+function start(it::Binomial)
+    BinomialIterState(collect(Int64, 1:it.k), (it.k > it.n) ? true : false)
+end
 
 function next(it::Binomial, state::BinomialIterState)
     idx = state.idx
@@ -739,13 +744,13 @@ nth(xs::Union{Tuple, AbstractArray}, n::Integer) = xs[n]
 
 # takenth(xs,n): take every n'th element from xs
 
-immutable TakeNth{I}
+struct TakeNth{I}
     xs::I
     interval::UInt
 end
-iteratorsize{I}(::Type{TakeNth{I}}) = longest(HasLength(), iteratorsize(I))
-iteratoreltype{I}(::Type{TakeNth{I}}) = iteratoreltype(I)
-eltype{I}(::Type{TakeNth{I}}) = eltype(I)
+iteratorsize(::Type{TakeNth{I}}) where {I} = longest(HasLength(), iteratorsize(I))
+iteratoreltype(::Type{TakeNth{I}}) where {I} = iteratoreltype(I)
+eltype(::Type{TakeNth{I}}) where {I} = eltype(I)
 length(x::TakeNth) = div(length(x.xs), x.interval)
 size(x::TakeNth) = (length(x),)
 
@@ -795,11 +800,11 @@ end
 
 done(it::TakeNth, state) = done(it.xs, state)
 
-immutable Iterate{T}
+struct Iterate{T}
     f::Function
     seed::T
 end
-iteratorsize{T<:Iterate}(::Type{T}) = IsInfinite()
+iteratorsize(::Type{<:Iterate}) = IsInfinite()
 
 """
     iterate(f, x)
@@ -836,7 +841,7 @@ done(it::Iterate, state) = (state==Union{})
 
 # peekiter(iter): possibility to peek the head of an iterator
 
-immutable PeekIter{I}
+struct PeekIter{I}
     it::I
 end
 
@@ -874,13 +879,13 @@ Nullable{String}("foo")
 """
 peekiter(itr) = PeekIter(itr)
 
-eltype{I}(::Type{PeekIter{I}}) = eltype(I)
-iteratorsize{I}(::Type{PeekIter{I}}) = iteratorsize(I)
-iteratoreltype{I}(::Type{PeekIter{I}}) = iteratoreltype(I)
+eltype(::Type{PeekIter{I}}) where {I} = eltype(I)
+iteratorsize(::Type{PeekIter{I}}) where {I} = iteratorsize(I)
+iteratoreltype(::Type{PeekIter{I}}) where {I} = iteratoreltype(I)
 length(f::PeekIter) = length(f.it)
 size(f::PeekIter) = size(f.it)
 
-function start{I}(f::PeekIter{I})
+function start(f::PeekIter{I}) where I
     s = start(f.it)
     if done(f.it, s)
         val = Nullable{eltype(I)}()
@@ -904,17 +909,19 @@ end
     return done(f.it, s) && isnull(val)
 end
 
-peek{I}(f::PeekIter{I}, state) = done(f, state) ? Nullable{eltype(I)}() : state[2]
+peek(f::PeekIter{I}, state) where {I} = done(f, state) ? Nullable{eltype(I)}() : state[2]
 
 
-start{T}(r::PeekIter{UnitRange{T}}) = start(r.it)
-next{T}(r::PeekIter{UnitRange{T}}, i) = next(r.it, i)
-done{T}(r::PeekIter{UnitRange{T}}, i) = done(r.it, i)
-peek{T}(r::PeekIter{UnitRange{T}}, i) = done(r.it, i) ? Nullable{T}() : Nullable{T}(next(r.it, i)[1])
+start(r::PeekIter{<:UnitRange}) = start(r.it)
+next(r::PeekIter{<:UnitRange}, i) = next(r.it, i)
+done(r::PeekIter{<:UnitRange}, i) = done(r.it, i)
+function peek(r::PeekIter{UnitRange{T}}, i) where T
+    done(r.it, i) ? Nullable{T}() : Nullable{T}(next(r.it, i)[1])
+end
 
 #NCycle - cycle through an object N times
 
-immutable NCycle{I}
+struct NCycle{I}
     iter::I
     n::Int
 end
@@ -938,10 +945,10 @@ i = 3
 """
 ncycle(iter, n::Int) = NCycle(iter, n)
 
-eltype{I}(nc::NCycle{I}) = eltype(I)
+eltype(nc::NCycle{I}) where {I} = eltype(I)
 length(nc::NCycle) = nc.n*length(nc.iter)
-iteratorsize{I}(::Type{NCycle{I}}) = longest(HasLength(), iteratorsize(I))
-iteratoreltype{I}(::Type{NCycle{I}}) = iteratoreltype(I)
+iteratorsize(::Type{NCycle{I}}) where {I} = longest(HasLength(), iteratorsize(I))
+iteratoreltype(::Type{NCycle{I}}) where {I} = iteratoreltype(I)
 
 start(nc::NCycle) = (start(nc.iter), 0)
 function next(nc::NCycle, state)

--- a/src/tuple_types.jl
+++ b/src/tuple_types.jl
@@ -1,9 +1,9 @@
-map_tt_t{T<:Tuple}(f, tt::Type{T}) = Base.tuple_type_cons(f(Base.tuple_type_head(tt)), map_tt_t(f, Base.tuple_type_tail(tt)))
+map_tt_t(f, tt::Type{<:Tuple}) = Base.tuple_type_cons(f(Base.tuple_type_head(tt)), map_tt_t(f, Base.tuple_type_tail(tt)))
 map_tt_t(f, tt::Type{Tuple{}}) = Tuple{}
 
 function mapreduce_tt(f, op, v0, tt)
     op(f(Base.tuple_type_head(tt)), mapreduce_tt(f, op, v0, Base.tuple_type_tail(tt)))
 end
 mapreduce_tt(f, op, v0, tt::Type{Tuple{}}) = v0
-mapreduce_tt{T}(f, op, v0, tt::Type{Tuple{T}}) = op(f(T), v0)
-mapreduce_tt{T}(f, op, v0, tt::Type{Tuple{Vararg{T}}}) = op(f(T), f(T))
+mapreduce_tt(f, op, v0, tt::Type{Tuple{T}}) where {T} = op(f(T), v0)
+mapreduce_tt(f, op, v0, tt::Type{Tuple{Vararg{T, N}} where N}) where {T} = op(f(T), f(T))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,629 +2,407 @@ using IterTools, Base.Test
 
 import Base: IsInfinite, SizeUnknown, HasLength, iteratorsize, HasShape
 
-# gets around deprecation warnings in v0.6
-if isdefined(Base, :Iterators)
-    import Base.Iterators: drop, countfrom, cycle, take, repeated
-end
-
-# count
-# -----
-
-i = 0
-c0 = countfrom(0, 2)
-
-@test eltype(c0) == Int
-
-for j in c0
-	@test j == i*2
-	i += 1
-	i <= 10 || break
-end
-
-# take
-# ----
-
-t = take(0:2:8, 10)
-
-@test length(collect(t)) == 5
-@test eltype(t) == Int
-
-i = 0
-for j = t
-	@test j == i*2
-	i += 1
-end
-@test i == 5
-
-i = 0
-for j = take(0:2:100, 10)
-	@test j == i*2
-	i += 1
-end
-@test i == 10
-
-# drop
-# ----
-
-d0 = drop(0:2:10, 2)
-
-@test eltype(d0) == Int
-
-i = 0
-for j in d0
-	@test j == (i+2)*2
-	i += 1
-end
-@test i == 4
-
-# cycle
-# -----
-
-cy1 = cycle(0:3)
-
-@test eltype(cy1) == Int
-
-i = 0
-for j in cy1
-	@test j == i % 4
-	i += 1
-	i <= 10 || break
-end
-
-# ncycle
-# ------
-
-ncy1 = ncycle(0:3,3)
-
-i = 0
-for j in ncy1
-    @test j == i % 4
-    i += 1
-end
-
-@test eltype(ncy1) == Int
-i = 0
-for j in collect(ncy1)
-    @test j == i % 4
-    i += 1
-end
-
-# repeated
-# --------
-
-r0 = repeated(1, 10)
-
-@test eltype(r0) == Int
-
-i = 0
-for j in r0
-	@test j == 1
-	i += 1
-end
-@test i == 10
-
-r1 = repeated(1)
-
-@test eltype(r1) == Int
-
-i = 0
-for j in r1
-	@test j == 1
-	i += 1
-	i <= 10 || break
-end
-
-# repeatedly
-# ----------
-
-i = 0
-for j = repeatedly(() -> 1, 10)
-	@test j == 1
-	i += 1
-end
-@test i == 10
-for j = repeatedly(() -> 1)
-	@test j == 1
-	i += 1
-	i <= 10 || break
-end
-
-# chain
-# -----
-
-ch1 = chain(1:2:5, 0.2:0.1:1.6)
-
-@test eltype(ch1) == typejoin(Int, Float64)
-@test collect(ch1) == [1:2:5; 0.2:0.1:1.6]
-
-ch2 = chain(1:0, 1:2:5, 0.2:0.1:1.6)
-
-@test eltype(ch2) == typejoin(Int, Float64)
-@test collect(ch2) == [1:2:5; 0.2:0.1:1.6]
-@test length(ch2) == length(collect(ch2))
-@test iteratorsize(ch2) == HasLength()
-
-ch3 = chain(1:10, 1:10, 1:10)
-@test length(ch3) == 30
-@test iteratorsize(ch3) == HasLength()
-
-r = countfrom(1)
-ch4 = chain(1:10, countfrom(1))
-@test eltype(ch4) == Int
-@test_throws MethodError length(ch4)
-@assert iteratorsize(r) == IsInfinite()
-@test iteratorsize(ch4) == IsInfinite()
-
-ch5 = chain()
-@test length(ch5) == 0
-@test iteratorsize(ch5) == HasLength()
-
-c = chain(ch1, ch2, ch3)
-@test length(c) == length(ch1) + length(ch2) + length(ch3)
-@test collect(c) == [collect(ch1); collect(ch2); collect(ch3)]
-
-r = rand(2,2)
-c = chain(r, r)
-@test length(c) == 8
-@test collect(c) == [vec(r); vec(r)]
-@test iteratorsize(r) == HasShape()
-@test iteratorsize(c) == HasLength()
-
-r = distinct(collect(1:10))
-@test iteratorsize(r) == SizeUnknown() #lazy filtering
-c = chain(1:10, r)
-@test_throws MethodError length(c)
-@test length(collect(c)) == 20
-@test iteratorsize(c) == SizeUnknown()
-
-# product
-# -------
-
-x1 = 1:2:10
-x2 = 1:5
-
-p0 = product(x1, x2)
-
-@test eltype(p0) == Tuple{Int, Int}
-@test collect(p0) == vec([(y1, y2) for y1 in x1, y2 in x2])
-
-p1 = product()
-
-@test eltype(p1) == Tuple{}
-@test length(p1) == 0
-
-# distinct
-# --------
-
-x = [5, 2, 2, 1, 2, 1, 1, 2, 4, 2]
-di0 = distinct(x)
-@test eltype(di0) == Int
-@test collect(di0) == unique(x)
-
-# partition
-# ---------
-
-pa0 = partition(take(countfrom(1), 6), 2)
-@test eltype(pa0) == Tuple{Int, Int}
-@test collect(pa0) == [(1,2), (3,4), (5,6)]
-
-pa1 = partition(take(countfrom(1), 4), 2, 1)
-@test eltype(pa1) == Tuple{Int, Int}
-@test collect(pa1) == [(1,2), (2,3), (3,4)]
-
-pa2 = partition(take(countfrom(1), 8), 2, 3)
-@test eltype(pa2) == Tuple{Int, Int}
-@test collect(pa2) == [(1,2), (4,5), (7,8)]
-
-pa3 = partition(take(countfrom(1), 0), 2, 1)
-@test eltype(pa3) == Tuple{Int, Int}
-@test collect(pa3) == []
-
-@test_throws ArgumentError partition(take(countfrom(1), 8), 2, 0)
-
-# imap
-# ----
-
-function test_imap(expected, input...)
-    result = collect(imap(+, input...))
-    @test result == expected
-end
-
-
-# Empty arrays
-test_imap(
-    Any[],
-    []
-)
-
-test_imap(
-    Any[],
-    Union{}[]
-)
-
-# Simple operation
-test_imap(
-    Any[1,2,3],
-    [1,2,3]
-)
-
-# Multiple arguments
-test_imap(
-    Any[5,7,9],
-    [1,2,3],
-    [4,5,6]
-)
-
-# Different-length arguments
-test_imap(
-    Any[2,4,6],
-    [1,2,3],
-    countfrom(1)
-)
-
-
-# groupby
-# -------
-
-function test_groupby(input, expected)
-    result = collect(groupby(x -> x[1], input))
-    @test result == expected
-end
-
-
-# Empty arrays
-test_groupby(
-    [],
-    Any[]
-)
-
-test_groupby(
-    Union{}[],
-    Any[]
-)
-
-# Singletons
-test_groupby(
-    ["xxx"],
-    Any[["xxx"]]
-)
-
-# Typical operation
-test_groupby(
-    ["face", "foo", "bar", "book", "baz"],
-    Any[["face", "foo"], ["bar", "book", "baz"]]
-)
-
-# Trailing singletons
-test_groupby(
-    ["face", "foo", "bar", "book", "baz", "xxx"],
-    Any[["face", "foo"], ["bar", "book", "baz"], ["xxx"]]
-)
-
-# Leading singletons
-test_groupby(
-    ["xxx", "face", "foo", "bar", "book", "baz"],
-    Any[["xxx"], ["face", "foo"], ["bar", "book", "baz"]]
-)
-
-# Middle singletons
-test_groupby(
-    ["face", "foo", "xxx", "bar", "book", "baz"],
-    Any[["face", "foo"], ["xxx"], ["bar", "book", "baz"]]
-)
-
-
-# subsets
-# -------
-
-s0 = subsets(Any[])
-@test eltype(eltype(s0)) == Any
-@test collect(s0) == Vector{Any}[Any[]]
-
-s1 = subsets([:a])
-@test eltype(eltype(s1)) == Symbol
-@test collect(s1) == Vector{Symbol}[Symbol[], Symbol[:a]]
-
-s2 = subsets([:a, :b, :c])
-@test eltype(eltype(s2)) == Symbol
-@test collect(s2) == Vector{Symbol}[
-    Symbol[], Symbol[:a], Symbol[:b], Symbol[:a, :b], Symbol[:c],
-    Symbol[:a, :c], Symbol[:b, :c], Symbol[:a, :b, :c],
-]
-
-
-# subsets of size k
-# -----------------
-
-sk0 = subsets(Any[],0)
-@test eltype(eltype(sk0)) == Any
-@test collect(sk0) == Vector{Any}[Any[]]
-
-sk1 = subsets([:a, :b, :c], 1)
-@test eltype(eltype(sk1)) == Symbol
-@test collect(sk1) == Vector{Symbol}[Symbol[:a], Symbol[:b], Symbol[:c]]
-
-sk2 = subsets([:a, :b, :c], 2)
-@test eltype(eltype(sk2)) == Symbol
-@test collect(sk2) == Vector{Symbol}[Symbol[:a,:b], Symbol[:a,:c], Symbol[:b,:c]]
-
-sk3 = subsets([:a, :b, :c], 3)
-@test eltype(eltype(sk3)) == Symbol
-@test collect(sk3) == Vector{Symbol}[Symbol[:a,:b,:c]]
-
-sk4 = subsets([:a, :b, :c], 4)
-@test eltype(eltype(sk4)) == Symbol
-@test collect(sk4) == Vector{Symbol}[]
-
-sk5 = subsets(collect(1:4), 1)
-@test eltype(eltype(sk5)) == Int
-@test length(collect(sk5)) == binomial(4,1)
-
-sk6 = subsets(collect(1:4), 2)
-@test eltype(eltype(sk6)) == Int
-@test length(collect(sk6)) == binomial(4,2)
-
-sk7 = subsets(collect(1:4), 3)
-@test eltype(eltype(sk7)) == Int
-@test length(collect(sk7)) == binomial(4,3)
-
-sk8 = subsets(collect(1:4), 4)
-@test eltype(eltype(sk8)) == Int
-@test length(collect(sk8)) == binomial(4,4)
-
-sk9 = subsets(collect(1:4), 5)
-@test eltype(eltype(sk9)) == Int
-@test length(collect(sk9)) == binomial(4,5)
-
-# Implicit conversions
-sk10 = subsets(1:4, 3)
-@test eltype(eltype(sk10)) == Int
-@test length(collect(sk10)) == binomial(4, 3)
-
-sk11 = subsets(1:3, Int32(2))
-@test eltype(eltype(sk11)) == Int
-@test length(collect(sk11)) == binomial(3, 2)
-
-
-# nth element
-# -----------
-for xs in Any[[1, 2, 3], 1:3, reshape(1:3, 3, 1)]
-    @test nth(xs, 3) == 3
-    @test_throws BoundsError nth(xs, 0)
-    @test_throws BoundsError nth(xs, 4)
-end
-
-for xs in Any[take(1:3, 3), drop(-1:3, 2)]
-    @test nth(xs, 3) == 3
-    @test_throws BoundsError nth(xs, 0)
-end
-
-s = subsets([1, 2, 3])
-@test_throws BoundsError nth(s, 0)
-@test_throws BoundsError nth(s, length(s) + 1)
-
-# #100
-nth(drop(repeatedly(() -> 1), 1), 1)
-
-
-# Every nth
-# ---------
-
-tn0 = takenth(Any[], 10)
-@test eltype(tn0) == Any
-@test collect(tn0) == Any[]
-
-tn1 = takenth(Int[], 10)
-@test eltype(tn1) == Int
-@test collect(tn1) == Int[]
-
-@test_throws ArgumentError takenth([], 0)
-
-tn2 = takenth(10:20, 3)
-@test eltype(tn2) == Int
-@test collect(tn2) == [12,15,18]
-
-tn3 = takenth(10:20, 1)
-@test eltype(tn3) == Int
-@test collect(tn3) == collect(10:20)
-
-
-# peekiter
-# --------
-pi0 = peekiter(1:10)
-@test eltype(pi0) == Int
-@test collect(pi0) == collect(1:10)
-
-pi1 = peekiter([])
-@test eltype(pi1) == eltype([])
-@test collect(pi1) == collect([])
-
-it = peekiter([:a, :b, :c])
-@test eltype(it) == Symbol
-s = start(it)
-@test get(peek(it, s)) == :a
-
-it = peekiter([])
-s = start(it)
-@test isnull(peek(it, s))
-
-it = peekiter(1:10)
-s = start(it)
-x, s = next(it, s)
-@test get(peek(it, s)) == 2
-
-
-## @itr
-## ====
-
-# @zip
-# ----
-
-macro test_zip(input...)
-    n = length(input)
-    x = Expr(:tuple, ntuple(i->gensym(), n)...)
-    v = Expr(:tuple, map(esc, input)...)
-    w = :(zip($(map(esc, input)...)))
-    quote
-	br = Any[]
-	for $x in zip($v...)
-	    push!(br, $x)
-	end
-	mr = Any[]
-	@itr for $x in $w
-	    push!(mr, $x)
-	end
-	@test br == mr
+import Base.Iterators: take, countfrom, drop
+
+include("testing_macros.jl")
+
+
+@testset "IterTools" begin
+@testset "iterators" begin
+    @testset "ncycle" begin
+        ncy1 = ncycle(0:3,3)
+
+        i = 0
+        for j in ncy1
+            @test j == i % 4
+            i += 1
+        end
+
+        @test eltype(ncy1) == Int
+        i = 0
+        for j in collect(ncy1)
+            @test j == i % 4
+            i += 1
+        end
+    end
+
+    @testset "repeatedly" begin
+        i = 0
+        for j = repeatedly(() -> 1, 10)
+            @test j == 1
+            i += 1
+        end
+        @test i == 10
+        for j = repeatedly(() -> 1)
+            @test j == 1
+            i += 1
+            i <= 10 || break
+        end
+    end
+
+    @testset "chain" begin
+        ch1 = chain(1:2:5, 0.2:0.1:1.6)
+
+        @test eltype(ch1) == typejoin(Int, Float64)
+        @test collect(ch1) == [1:2:5; 0.2:0.1:1.6]
+
+        ch2 = chain(1:0, 1:2:5, 0.2:0.1:1.6)
+
+        @test eltype(ch2) == typejoin(Int, Float64)
+        @test collect(ch2) == [1:2:5; 0.2:0.1:1.6]
+        @test length(ch2) == length(collect(ch2))
+        @test iteratorsize(ch2) == HasLength()
+
+        ch3 = chain(1:10, 1:10, 1:10)
+        @test length(ch3) == 30
+        @test iteratorsize(ch3) == HasLength()
+
+        r = countfrom(1)
+        ch4 = chain(1:10, countfrom(1))
+        @test eltype(ch4) == Int
+        @test_throws MethodError length(ch4)
+        @assert iteratorsize(r) == IsInfinite()
+        @test iteratorsize(ch4) == IsInfinite()
+
+        ch5 = chain()
+        @test length(ch5) == 0
+        @test iteratorsize(ch5) == HasLength()
+
+        c = chain(ch1, ch2, ch3)
+        @test length(c) == length(ch1) + length(ch2) + length(ch3)
+        @test collect(c) == [collect(ch1); collect(ch2); collect(ch3)]
+
+        r = rand(2,2)
+        c = chain(r, r)
+        @test length(c) == 8
+        @test collect(c) == [vec(r); vec(r)]
+        @test iteratorsize(r) == HasShape()
+        @test iteratorsize(c) == HasLength()
+
+        r = distinct(collect(1:10))
+        @test iteratorsize(r) == SizeUnknown() #lazy filtering
+        c = chain(1:10, r)
+        @test_throws MethodError length(c)
+        @test length(collect(c)) == 20
+        @test iteratorsize(c) == SizeUnknown()
+    end
+
+    @testset "product" begin
+        x1 = 1:2:10
+        x2 = 1:5
+
+        p0 = product(x1, x2)
+
+        @test eltype(p0) == Tuple{Int, Int}
+        @test collect(p0) == vec([(y1, y2) for y1 in x1, y2 in x2])
+
+        p1 = product()
+
+        @test eltype(p1) == Tuple{}
+        @test length(p1) == 0
+    end
+
+    @testset "distinct" begin
+        x = [5, 2, 2, 1, 2, 1, 1, 2, 4, 2]
+        di0 = distinct(x)
+        @test eltype(di0) == Int
+        @test collect(di0) == unique(x)
+    end
+
+    @testset "partition" begin
+        pa0 = partition(take(countfrom(1), 6), 2)
+        @test eltype(pa0) == Tuple{Int, Int}
+        @test collect(pa0) == [(1,2), (3,4), (5,6)]
+
+        pa1 = partition(take(countfrom(1), 4), 2, 1)
+        @test eltype(pa1) == Tuple{Int, Int}
+        @test collect(pa1) == [(1,2), (2,3), (3,4)]
+
+        pa2 = partition(take(countfrom(1), 8), 2, 3)
+        @test eltype(pa2) == Tuple{Int, Int}
+        @test collect(pa2) == [(1,2), (4,5), (7,8)]
+
+        pa3 = partition(take(countfrom(1), 0), 2, 1)
+        @test eltype(pa3) == Tuple{Int, Int}
+        @test collect(pa3) == []
+
+        @test_throws ArgumentError partition(take(countfrom(1), 8), 2, 0)
+    end
+
+    @testset "imap" begin
+        function test_imap(expected, input...)
+            result = collect(imap(+, input...))
+            @test result == expected
+        end
+
+        @testset "empty arrays" begin
+            test_imap(
+                Any[],
+                []
+            )
+
+            test_imap(
+                Any[],
+                Union{}[]
+            )
+        end
+
+        @testset "simple operation" begin
+            test_imap(
+                Any[1,2,3],
+                [1,2,3]
+            )
+        end
+
+        @testset "multiple arguments" begin
+            test_imap(
+                Any[5,7,9],
+                [1,2,3],
+                [4,5,6]
+            )
+        end
+
+        @testset "different-length arguments" begin
+            test_imap(
+                Any[2,4,6],
+                [1,2,3],
+                countfrom(1)
+            )
+        end
+    end
+
+
+    @testset "groupby" begin
+        function test_groupby(input, expected)
+            result = collect(groupby(x -> x[1], input))
+            @test result == expected
+        end
+
+        @testset "empty arrays" begin
+            test_groupby(
+                [],
+                Any[]
+            )
+
+            test_groupby(
+                Union{}[],
+                Any[]
+            )
+        end
+
+        @testset "singletons" begin
+            test_groupby(
+                ["xxx"],
+                Any[["xxx"]]
+            )
+        end
+
+        @testset "typical operation" begin
+            test_groupby(
+                ["face", "foo", "bar", "book", "baz"],
+                Any[["face", "foo"], ["bar", "book", "baz"]]
+            )
+        end
+
+        @testset "trailing singletons" begin
+            test_groupby(
+                ["face", "foo", "bar", "book", "baz", "xxx"],
+                Any[["face", "foo"], ["bar", "book", "baz"], ["xxx"]]
+            )
+        end
+
+        @testset "leading singletons" begin
+            test_groupby(
+                ["xxx", "face", "foo", "bar", "book", "baz"],
+                Any[["xxx"], ["face", "foo"], ["bar", "book", "baz"]]
+            )
+        end
+
+        @testset "middle singletons" begin
+            test_groupby(
+                ["face", "foo", "xxx", "bar", "book", "baz"],
+                Any[["face", "foo"], ["xxx"], ["bar", "book", "baz"]]
+            )
+        end
+    end
+
+    @testset "subsets" begin
+        @testset "all lengths" begin
+            s0 = subsets(Any[])
+            @test eltype(eltype(s0)) == Any
+            @test collect(s0) == Vector{Any}[Any[]]
+
+            s1 = subsets([:a])
+            @test eltype(eltype(s1)) == Symbol
+            @test collect(s1) == Vector{Symbol}[Symbol[], Symbol[:a]]
+
+            s2 = subsets([:a, :b, :c])
+            @test eltype(eltype(s2)) == Symbol
+            @test collect(s2) == Vector{Symbol}[
+                Symbol[], Symbol[:a], Symbol[:b], Symbol[:a, :b], Symbol[:c],
+                Symbol[:a, :c], Symbol[:b, :c], Symbol[:a, :b, :c],
+            ]
+        end
+
+        @testset "specific length" begin
+            sk0 = subsets(Any[],0)
+            @test eltype(eltype(sk0)) == Any
+            @test collect(sk0) == Vector{Any}[Any[]]
+
+            sk1 = subsets([:a, :b, :c], 1)
+            @test eltype(eltype(sk1)) == Symbol
+            @test collect(sk1) == Vector{Symbol}[Symbol[:a], Symbol[:b], Symbol[:c]]
+
+            sk2 = subsets([:a, :b, :c], 2)
+            @test eltype(eltype(sk2)) == Symbol
+            @test collect(sk2) == Vector{Symbol}[Symbol[:a,:b], Symbol[:a,:c], Symbol[:b,:c]]
+
+            sk3 = subsets([:a, :b, :c], 3)
+            @test eltype(eltype(sk3)) == Symbol
+            @test collect(sk3) == Vector{Symbol}[Symbol[:a,:b,:c]]
+
+            sk4 = subsets([:a, :b, :c], 4)
+            @test eltype(eltype(sk4)) == Symbol
+            @test collect(sk4) == Vector{Symbol}[]
+
+            @testset for i in 1:5
+                sk5 = subsets(collect(1:4), i)
+                @test eltype(eltype(sk5)) == Int
+                @test length(collect(sk5)) == binomial(4, i)
+            end
+
+            @testset "implicit conversions" begin
+                sk10 = subsets(1:4, 3)
+                @test eltype(eltype(sk10)) == Int
+                @test length(collect(sk10)) == binomial(4, 3)
+
+                sk11 = subsets(1:3, Int32(2))
+                @test eltype(eltype(sk11)) == Int
+                @test length(collect(sk11)) == binomial(3, 2)
+            end
+        end
+    end
+
+    @testset "nth" begin
+        @testset for xs in Any[[1, 2, 3], 1:3, reshape(1:3, 3, 1)]
+            @test nth(xs, 3) == 3
+            @test_throws BoundsError nth(xs, 0)
+            @test_throws BoundsError nth(xs, 4)
+        end
+
+        @testset for xs in Any[take(1:3, 3), drop(-1:3, 2)]
+            @test nth(xs, 3) == 3
+            @test_throws BoundsError nth(xs, 0)
+        end
+
+        s = subsets([1, 2, 3])
+        @test_throws BoundsError nth(s, 0)
+        @test_throws BoundsError nth(s, length(s) + 1)
+
+        # #100
+        @test nth(drop(repeatedly(() -> 1), 1), 1) == 1
+    end
+
+
+    @testset "takenth" begin
+        tn0 = takenth(Any[], 10)
+        @test eltype(tn0) == Any
+        @test collect(tn0) == Any[]
+
+        tn1 = takenth(Int[], 10)
+        @test eltype(tn1) == Int
+        @test collect(tn1) == Int[]
+
+        @test_throws ArgumentError takenth([], 0)
+
+        tn2 = takenth(10:20, 3)
+        @test eltype(tn2) == Int
+        @test collect(tn2) == [12,15,18]
+
+        tn3 = takenth(10:20, 1)
+        @test eltype(tn3) == Int
+        @test collect(tn3) == collect(10:20)
+    end
+
+
+    @testset "peekiter" begin
+        pi0 = peekiter(1:10)
+        @test eltype(pi0) == Int
+        @test collect(pi0) == collect(1:10)
+
+        pi1 = peekiter([])
+        @test eltype(pi1) == eltype([])
+        @test collect(pi1) == collect([])
+
+        it = peekiter([:a, :b, :c])
+        @test eltype(it) == Symbol
+        s = start(it)
+        @test get(peek(it, s)) == :a
+
+        it = peekiter([])
+        s = start(it)
+        @test isnull(peek(it, s))
+
+        it = peekiter(1:10)
+        s = start(it)
+        x, s = next(it, s)
+        @test get(peek(it, s)) == 2
     end
 end
 
-@test_zip [1,2,3] [:a, :b, :c] ['x', 'y', 'z']
-@test_zip [1,2,3] [:a, :b] ['w', 'x', 'y', 'z']
-@test_zip [1,2,3] Any[] ['w', 'x', 'y', 'z']
-@test_zip [1,2,3] Union{}[] ['w', 'x', 'y', 'z']
+@testset "@itr" begin
+    @testset "@zip" begin
+        @test_zip [1,2,3] [:a, :b, :c] ['x', 'y', 'z']
+        @test_zip [1,2,3] [:a, :b] ['w', 'x', 'y', 'z']
+        @test_zip [1,2,3] Any[] ['w', 'x', 'y', 'z']
+        @test_zip [1,2,3] Union{}[] ['w', 'x', 'y', 'z']
+    end
 
-# @enumerate
-# ----------
+    @testset "@enumerate" begin
+        @test_enumerate [:a, :b, :c]
+        @test_enumerate Union{}[]
+        @test_enumerate Any[]
+    end
 
-macro test_enumerate(input)
-    i = gensym()
-    x = gensym()
-    v = esc(input)
-    quote
-	br = Any[]
-	for ($i,$x) in enumerate($v)
-	    push!(br, ($i,$x))
-	end
-	mr = Any[]
-	@itr for ($i,$x) in enumerate($v)
-	    push!(mr, ($i,$x))
-	end
-	@test br == mr
+    @testset "@take" begin
+        @test_take [:a, :b, :c] 2
+        @test_take [:a, :b, :c] 5
+        @test_take [:a, :b, :c] 0
+        @test_take Any[] 2
+        @test_take Union{}[] 2
+        @test_take Any[] 0
+        @test_take [(:a,1), (:b,2), (:c,3)] 2
+    end
+
+    @testset "@takestrict" begin
+        @test_takestrict [:a, :b, :c] 2
+        @test_takestrict [:a, :b, :c] 3
+        @test_takestrict [:a, :b, :c] 5
+        @test_takestrict [:a, :b, :c] 0
+        @test_takestrict Any[] 2
+        @test_takestrict Union{}[] 2
+        @test_takestrict Any[] 0
+        @test_takestrict [(:a,1), (:b,2), (:c,3)] 2
+        @test_takestrict [(:a,1), (:b,2), (:c,3)] 3
+        @test_takestrict [(:a,1), (:b,2), (:c,3)] 4
+    end
+
+    @testset "@drop" begin
+        @test_drop [:a, :b, :c] 2
+        @test_drop [:a, :b, :c] 5
+        @test_drop [:a, :b, :c] 0
+        @test_drop Any[] 2
+        @test_drop Union{}[] 2
+        @test_drop Any[] 0
+        @test_drop [(:a,1), (:b,2), (:c,3)] 2
+    end
+
+    @testset "@chain" begin
+        @test_chain [1,2,3] [:a, :b, :c] ['x', 'y', 'z']
+        @test_chain [1,2,3] [:a, :b] ['w', 'x', 'y', 'z']
+        @test_chain [1,2,3] Any[] ['w', 'x', 'y', 'z']
+        @test_chain [1,2,3] Union{}[] ['w', 'x', 'y', 'z']
+        @test_chain [1,2,3] 4 [('w',3), ('x',2), ('y',1), ('z',0)]
     end
 end
-
-@test_enumerate [:a, :b, :c]
-@test_enumerate Union{}[]
-@test_enumerate Any[]
-
-# @take
-# -----
-
-macro test_take(input, n)
-    x = gensym()
-    v = esc(input)
-    quote
-	br = Any[]
-	for $x in take($v, $n)
-	    push!(br, $x)
-	end
-	mr = Any[]
-	@itr for $x in take($v, $n)
-	    push!(mr, $x)
-	end
-	@test br == mr
-    end
 end
-
-@test_take [:a, :b, :c] 2
-@test_take [:a, :b, :c] 5
-@test_take [:a, :b, :c] 0
-@test_take Any[] 2
-@test_take Union{}[] 2
-@test_take Any[] 0
-@test_take [(:a,1), (:b,2), (:c,3)] 2
-
-# @takestrict
-# -----
-
-macro test_takestrict(input, n)
-    x = gensym()
-    v = esc(input)
-    quote
-	br = Any[]
-	bfailed = false
-	try
-	    for $x in takestrict($v, $n)
-		push!(br, $x)
-	    end
-	catch
-	    bfailed = true
-	end
-
-	mr = Any[]
-	mfailed = false
-	try
-	    @itr for $x in takestrict($v, $n)
-		push!(mr, $x)
-	    end
-	catch
-	    mfailed = true
-	end
-	@test br == mr
-	@test bfailed == mfailed
-    end
-end
-
-@test_takestrict [:a, :b, :c] 2
-@test_takestrict [:a, :b, :c] 3
-@test_takestrict [:a, :b, :c] 5
-@test_takestrict [:a, :b, :c] 0
-@test_takestrict Any[] 2
-@test_takestrict Union{}[] 2
-@test_takestrict Any[] 0
-@test_takestrict [(:a,1), (:b,2), (:c,3)] 2
-@test_takestrict [(:a,1), (:b,2), (:c,3)] 3
-@test_takestrict [(:a,1), (:b,2), (:c,3)] 4
-
-# @drop
-# -----
-
-macro test_drop(input, n)
-    x = gensym()
-    v = esc(input)
-    quote
-	br = Any[]
-	for $x in drop($v, $n)
-	    push!(br, $x)
-	end
-	mr = Any[]
-	@itr for $x in drop($v, $n)
-	    push!(mr, $x)
-	end
-	@test br == mr
-    end
-end
-
-@test_drop [:a, :b, :c] 2
-@test_drop [:a, :b, :c] 5
-@test_drop [:a, :b, :c] 0
-@test_drop Any[] 2
-@test_drop Union{}[] 2
-@test_drop Any[] 0
-@test_drop [(:a,1), (:b,2), (:c,3)] 2
-
-# @chain
-# -----
-
-macro test_chain(input...)
-    x = gensym()
-    v = Expr(:tuple, map(esc, input)...)
-    w = :(chain($(map(esc, input)...)))
-    quote
-	br = Any[]
-	for $x in chain($v...)
-	    push!(br, $x)
-	end
-	mr = Any[]
-	@itr for $x in $w
-	    push!(mr, $x)
-	end
-	@test br == mr
-    end
-end
-
-@test_chain [1,2,3] [:a, :b, :c] ['x', 'y', 'z']
-@test_chain [1,2,3] [:a, :b] ['w', 'x', 'y', 'z']
-@test_chain [1,2,3] Any[] ['w', 'x', 'y', 'z']
-@test_chain [1,2,3] Union{}[] ['w', 'x', 'y', 'z']
-@test_chain [1,2,3] 4 [('w',3), ('x',2), ('y',1), ('z',0)]

--- a/test/testing_macros.jl
+++ b/test/testing_macros.jl
@@ -1,0 +1,111 @@
+macro test_zip(input...)
+    n = length(input)
+    x = Expr(:tuple, ntuple(i->gensym(), n)...)
+    v = Expr(:tuple, map(esc, input)...)
+    w = :(zip($(map(esc, input)...)))
+    quote
+    br = Any[]
+    for $x in zip($v...)
+        push!(br, $x)
+    end
+    mr = Any[]
+    @itr for $x in $w
+        push!(mr, $x)
+    end
+    @test br == mr
+    end
+end
+
+macro test_enumerate(input)
+    i = gensym()
+    x = gensym()
+    v = esc(input)
+    quote
+    br = Any[]
+    for ($i,$x) in enumerate($v)
+        push!(br, ($i,$x))
+    end
+    mr = Any[]
+    @itr for ($i,$x) in enumerate($v)
+        push!(mr, ($i,$x))
+    end
+    @test br == mr
+    end
+end
+
+macro test_take(input, n)
+    x = gensym()
+    v = esc(input)
+    quote
+    br = Any[]
+    for $x in take($v, $n)
+        push!(br, $x)
+    end
+    mr = Any[]
+    @itr for $x in take($v, $n)
+        push!(mr, $x)
+    end
+    @test br == mr
+    end
+end
+
+macro test_takestrict(input, n)
+    x = gensym()
+    v = esc(input)
+    quote
+    br = Any[]
+    bfailed = false
+    try
+        for $x in takestrict($v, $n)
+            push!(br, $x)
+        end
+    catch
+        bfailed = true
+    end
+
+    mr = Any[]
+    mfailed = false
+    try
+        @itr for $x in takestrict($v, $n)
+            push!(mr, $x)
+        end
+    catch
+        mfailed = true
+    end
+    @test br == mr
+    @test bfailed == mfailed
+    end
+end
+
+macro test_drop(input, n)
+    x = gensym()
+    v = esc(input)
+    quote
+    br = Any[]
+    for $x in drop($v, $n)
+        push!(br, $x)
+    end
+    mr = Any[]
+    @itr for $x in drop($v, $n)
+        push!(mr, $x)
+    end
+    @test br == mr
+    end
+end
+
+macro test_chain(input...)
+    x = gensym()
+    v = Expr(:tuple, map(esc, input)...)
+    w = :(chain($(map(esc, input)...)))
+    quote
+    br = Any[]
+    for $x in chain($v...)
+        push!(br, $x)
+    end
+    mr = Any[]
+    @itr for $x in $w
+        push!(mr, $x)
+    end
+    @test br == mr
+    end
+end


### PR DESCRIPTION
This uses 0.6+ syntax, adds testsets, and removes some `Base.Iterators` imports (which weren't used or exported, but were tested). 

I also allowed failures on 0.7 (currently failing due to the macro shenanigans I think) and stopped testing on OS X since I don't expect OS to make a difference for this package and OS X runners get backed up on Travis.