### PR TITLE
Document @ifsomething, making it part of the API.

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -108,3 +108,11 @@ Equivalent to `take`, but will throw an exception if fewer than `n` items are en
 ```@docs
 takestrict
 ```
+
+## IterTools.@ifsomething
+
+Helper macro for returning from the enclosing block when there are no more elements.
+
+```@docs
+IterTools.@ifsomething
+```

--- a/src/IterTools.jl
+++ b/src/IterTools.jl
@@ -59,6 +59,19 @@ shortest(::SizeUnknown, ::HasShape) = SizeUnknown()
 shortest(::SizeUnknown, ::HasLength) = SizeUnknown()
 shortest(::SizeUnknown, ::IsInfinite) = SizeUnknown()
 
+"""
+    IterTools.@ifsomething expr
+
+If `expr` evaluates to `nothing`, equivalent to `return nothing`, otherwise the macro
+evaluates to the value of `expr`. Not exported, useful for implementing iterators.
+
+```jldoctest
+julia> IterTools.@ifsomething iterate(1:2)
+(1, 1)
+
+julia> let elt, state = IterTools.@ifsomething iterate(1:2, 2); println("not reached"); end
+```
+"""
 macro ifsomething(ex)
     quote
         result = $(esc(ex))


### PR DESCRIPTION
Rationale: it is useful for writing iterators. The PR does not export it, but documenting makes it part of the API for package developers.