### PR TITLE
Add FieldValues iterator

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -109,6 +109,14 @@ Equivalent to `take`, but will throw an exception if fewer than `n` items are en
 takestrict
 ```
 
+## fieldvalues(x)
+
+Like `(getfield(x, i) for i in 1:nfields(x))` but faster.
+
+```@docs
+fieldvalues
+```
+
 ## IterTools.@ifsomething
 
 Helper macro for returning from the enclosing block when there are no more elements.

--- a/src/IterTools.jl
+++ b/src/IterTools.jl
@@ -997,7 +997,6 @@ julia> collect(fieldvalues(1 + 2im))
  2
 ```
 """
-
 fieldvalues(x::T) where {T} = FieldValues{T}(x)
 length(fs::FieldValues{T}) where {T} = fieldcount(T)
 IteratorSize(::Type{<:FieldValues}) = HasLength()

--- a/src/IterTools.jl
+++ b/src/IterTools.jl
@@ -25,7 +25,8 @@ export
     takenth,
     peekiter,
     peek,
-    ncycle
+    ncycle,
+    fieldvalues
 
 function has_length(it)
     it_size = IteratorSize(it)
@@ -801,6 +802,32 @@ function iterate(nc::NCycle, state=(nc.n,))
 
     v, inner_state = inner_iter
     return v, (n, inner_state)
+end
+
+struct FieldValues{T}
+    x::T
+end
+
+"""
+    fieldvalues(x)
+
+Iterate through the values of the fields of `x`.
+
+```jldoctest
+julia> collect(fieldvalues(1 + 2im))
+2-element Array{Any,1}:
+ 1
+ 2
+```
+"""
+fieldvalues(x::T) where {T} = FieldValues{T}(x)
+length(fs::FieldValues{T}) where {T} = fieldcount(T)
+IteratorSize(::Type{<:FieldValues}) = HasLength()
+
+function iterate(fs::FieldValues, state=1)
+    state > length(fs) && return nothing
+
+    return (getfield(fs.x, state), state + 1)
 end
 
 end # module IterTools

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -381,5 +381,22 @@ include("testing_macros.jl")
         @test peek(it, s) === nothing
         @test iterate(it, s) === nothing
     end
+
+    @testset "fieldvalues" begin
+        fv1 = fieldvalues(1 + 2im)
+        @test IteratorEltype(fv1) isa HasEltype
+        @test eltype(fv1) == Any
+        @test IteratorSize(fv1) isa HasLength
+        @test length(fv1) == 2
+        @test collect(fv1) == Any[1, 2]
+
+        tp = ("", 1, 2.0)
+        fv2 = fieldvalues(tp)
+        @test collect(fv2) == collect(tp)
+
+        # HasLength used as an example no-field struct
+        fv3 = fieldvalues(HasLength())
+        @test collect(fv3) == Any[]
+    end
 end
 end


### PR DESCRIPTION
It's like `(getfield(x, i) for i in 1:nfields(x))` but faster.

I considered making it a lazy array type instead but that was slower and I didn't feel like digging into why.