### PR TITLE
Add IVec: lazy `vec`

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -68,6 +68,14 @@ Group values into `n`-tuples.
 partition
 ```
 
+## ivec(xs)
+
+Iterate over `xs` but do not preserve shape information.
+
+```@docs
+ivec
+```
+
 ## peekiter(xs)
 
 Peek at the head element of an iterator without updating the state.

--- a/src/IterTools.jl
+++ b/src/IterTools.jl
@@ -25,7 +25,8 @@ export
     takenth,
     peekiter,
     peek,
-    ncycle
+    ncycle,
+    ivec
 
 function has_length(it)
     it_size = IteratorSize(it)
@@ -802,5 +803,42 @@ function iterate(nc::NCycle, state=(nc.n,))
     v, inner_state = inner_iter
     return v, (n, inner_state)
 end
+
+# IVec - lazy `vec`-like iterator that drops shape
+
+struct IVec{I}
+    iter::I
+end
+
+"""
+    ivec(iter)
+
+Drops all shape from `iter` while iterating.
+Like a non-materializing version of [`vec`](https://docs.julialang.org/en/stable/base/arrays/#Base.vec).
+
+```jldoctest
+julia> m = collect(reshape(1:6, 2, 3))
+2×3 Array{Int64,2}:
+ 1  3  5
+ 2  4  6
+
+julia> collect(ivec(m))
+6-element Array{Int64,1}:
+ 1
+ 2
+ 3
+ 4
+ 5
+ 6
+```
+"""
+ivec(iter) = IVec(iter)
+
+eltype(iv::IVec) = eltype(iv.iter)
+length(iv::IVec) = length(iv.iter)
+IteratorSize(::Type{IVec{I}}) where {I} = longest(HasLength(), IteratorSize(I))
+IteratorEltype(::Type{IVec{I}}) where {I} = IteratorEltype(I)
+
+iterate(iv::IVec, state...) = iterate(iv.iter, state...)
 
 end # module IterTools

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -381,5 +381,18 @@ include("testing_macros.jl")
         @test peek(it, s) === nothing
         @test iterate(it, s) === nothing
     end
+
+    @testset "ivec" begin
+        irange = 1:12
+        vector = collect(irange)
+        @test collect(ivec(irange)) == vector
+        @test collect(ivec(vector)) == vector
+
+        matrix = reshape(vector, 3, 4)
+        @test collect(ivec(matrix)) == vector
+
+        ndarray = reshape(vector, 2, 2, 3)
+        @test collect(ivec(ndarray)) == vector
+    end
 end
 end


### PR DESCRIPTION
It's like `vec` but it doesn't materialize an array. Turns an n-dimensional iterator into a 1-dimensional iterator.