### PR TITLE
Use `isequal` rather than `==` to handle `missing` values in `groupby`.

### DIFF
--- a/src/IterTools.jl
+++ b/src/IterTools.jl
@@ -383,7 +383,7 @@ function iterate(it::GroupBy{I, F}, state=nothing) where {I, F<:Base.Callable}
         val, xs_state = xs_iter
         key = it.keyfunc(val)
 
-        if key == prev_key
+        if isequal(key, prev_key)
             push!(values, val)
         else
             prev_key = key


### PR DESCRIPTION
This allows for `missing` values to be grouped together rather than throwing an error.

Note that this affects a few other cases, such as -0.0 and 0.0, as described [here](https://docs.julialang.org/en/v1/base/base/index.html#Base.isequal). If we don't want those to be grouped, then this functionality could be implemented as an `ismissing` check.