### PR TITLE
support negative k for k-subsets

### DIFF
--- a/src/IterTools.jl
+++ b/src/IterTools.jl
@@ -556,11 +556,14 @@ end
 IteratorSize(::Type{StaticSizeBinomial{K, C}}) where {K, C} = HasLength()
 IteratorEltype(::Type{StaticSizeBinomial{K, C}}) where {K, C} = IteratorEltype(C)
 
-eltype(::Type{StaticSizeBinomial{K, C}}) where {K, C} = NTuple{K, eltype(C)}
+eltype(::Type{StaticSizeBinomial{K, C}}) where {K, C} = K < 0 ? Union{} : NTuple{K, eltype(C)}
 length(it::StaticSizeBinomial{K}) where {K} = binomial(length(it.xs), K)
 
 subsets(xs::C, ::Val{K}) where {K, C} = StaticSizeBinomial{K, C}(xs)
 
+# Special case for K < 0
+iterate(it::StaticSizeBinomial{k}) where k = k < 0 ? nothing : _iterate(it)
+iterate(it::StaticSizeBinomial{k}, state) where k = k < 0 ? nothing : _iterate(it, state)
 # Special case for K == 0
 iterate(it::StaticSizeBinomial{0}, state=false) = state ? nothing : ((), true)
 
@@ -579,7 +582,7 @@ function advance(it::StaticSizeBinomial{K}, idx) where {K}
 end
 advance(it::StaticSizeBinomial, idx::NTuple{1}) = (idx[end]+1,)
 
-function iterate(it::StaticSizeBinomial{K}, idx=ntuple(identity, Val{K}())) where K
+function _iterate(it::StaticSizeBinomial{K}, idx=ntuple(identity, Val{K}())) where K
     idx[end] > length(it.xs) && return nothing
     return (map(i -> it.xs[i], idx), advance(it, idx))
 end

--- a/src/IterTools.jl
+++ b/src/IterTools.jl
@@ -521,7 +521,7 @@ mutable struct BinomialIterState
     done::Bool
 end
 
-function iterate(it::Binomial, state=BinomialIterState(collect(Int64, 1:it.k), it.k > it.n))
+function iterate(it::Binomial, state=BinomialIterState(collect(Int64, 1:it.k), it.k > it.n || it.k < 0))
     state.done && return nothing
 
     idx = state.idx

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -267,6 +267,8 @@ include("testing_macros.jl")
             @testset for i in -1:6
                 sk5 = subsets(collect(1:4), Val{i}())
                 # there is no sensible element type information for i < 1
+                i < 0 && @test eltype(sk5) == Union{}
+                i == 0 && @test eltype(sk5) == Tuple{}
                 i >= 1 && @test eltype(eltype(sk5)) == Int
                 @test length(collect(sk5)) == binomial(4, i)
             end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -223,7 +223,7 @@ include("testing_macros.jl")
             @test eltype(eltype(sk4)) == Symbol
             @test collect(sk4) == Vector{Symbol}[]
 
-            @testset for i in 1:5
+            @testset for i in -1:5
                 sk5 = subsets(collect(1:4), i)
                 @test eltype(eltype(sk5)) == Int
                 @test length(collect(sk5)) == binomial(4, i)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -264,9 +264,10 @@ include("testing_macros.jl")
             @test eltype(eltype(sk5)) == Symbol
             @test collect(sk5) == []
 
-            @testset for i in 1:6
+            @testset for i in -1:6
                 sk5 = subsets(collect(1:4), Val{i}())
-                @test eltype(eltype(sk5)) == Int
+                # there is no sensible element type information for i < 1
+                i >= 1 && @test eltype(eltype(sk5)) == Int
                 @test length(collect(sk5)) == binomial(4, i)
             end
 


### PR DESCRIPTION
We have `binomial(n, k)=0` for `k<0` and `k>n`.
This makes `subsets` comply accordingly instead of creating wrong iterators or throwing errors.