### PR TITLE
Refer to equivalent function in Base

### DIFF
--- a/src/IterTools.jl
+++ b/src/IterTools.jl
@@ -90,6 +90,8 @@ end
 
 Return the first element and an iterator of the rest as a tuple.
 
+See also: `Base.Iterators.peel`.
+
 ```jldoctest
 julia> f, r = firstrest(1:3)
 (1, Base.Iterators.Rest{UnitRange{Int64},Int64}(1:3, 1))


### PR DESCRIPTION
As discussed in https://github.com/JuliaCollections/IterTools.jl/pull/66, there is an identical function (modulo the exception) in `Base.Iterators`. 