### PR TITLE
interleaveby iterator

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -171,3 +171,11 @@ Like `(getfield(x, i) for i in 1:nfields(x))` but faster.
 ```@docs
 fieldvalues
 ```
+
+## imerge(a,b, predicate = <=, fa = identity, fb = identity)
+
+Iterate over the union of `a` and `b`, merge-sort style.
+
+```@docs
+imerge
+```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -172,10 +172,10 @@ Like `(getfield(x, i) for i in 1:nfields(x))` but faster.
 fieldvalues
 ```
 
-## imerge(a,b, predicate = <=, fa = identity, fb = identity)
+## interleaveby(a,b, predicate = <=, fa = identity, fb = identity)
 
 Iterate over the union of `a` and `b`, merge-sort style.
 
 ```@docs
-imerge
+interleaveby
 ```

--- a/src/IterTools.jl
+++ b/src/IterTools.jl
@@ -31,7 +31,7 @@ export
     properties,
     propertyvalues,
     fieldvalues,
-    imerge
+    interleaveby
 
 function has_length(it)
     it_size = IteratorSize(it)
@@ -1028,10 +1028,10 @@ function iterate(fs::FieldValues, state=1)
     return (getfield(fs.x, state), state + 1)
 end
 
-# IMerge
+# InterleaveBy
 
 """
-    imerge(a,b, predicate = <=, fa = identity, fb = identity)
+    interleaveby(a,b, predicate = <=, fa = identity, fb = identity)
 
 Iterate over the union of `a` and `b`, merge-sort style.
 
@@ -1041,7 +1041,7 @@ Input:
  - `fa(ak)`, `fb(bk)`: Functions to apply to the picked elements
 
 ```jldoctest
-julia> collect(imerge(1:2:5, 2:2:6, <=, identity, x->-x))
+julia> collect(interleaveby(1:2:5, 2:2:6, <=, identity, x->-x))
 6-element Vector{Int64}:
   1
  -2
@@ -1051,9 +1051,9 @@ julia> collect(imerge(1:2:5, 2:2:6, <=, identity, x->-x))
  -6
 ```
 """
-imerge(a,b, p = <=, fa = identity, fb = identity) = IMerge(a,b,p,fa,fb)
+interleaveby(a,b, p = <=, fa = identity, fb = identity) = InterleaveBy(a,b,p,fa,fb)
 
-struct IMerge{A,B,P,FA,FB}
+struct InterleaveBy{A,B,P,FA,FB}
     a::A
     b::B
     predicate::P
@@ -1061,11 +1061,11 @@ struct IMerge{A,B,P,FA,FB}
     fb::FB
 end
 
-Base.IteratorSize(::Type{<:IMerge{A,B}}) where {A,B} = longest(Base.IteratorSize.((A,B))...)
-Base.length(m::IMerge) = length(m.a) + length(m.b)
-Base.IteratorEltype(::Type{<:IMerge}) = Base.EltypeUnknown()
+Base.IteratorSize(::Type{<:InterleaveBy{A,B}}) where {A,B} = longest(Base.IteratorSize.((A,B))...)
+Base.length(m::InterleaveBy) = length(m.a) + length(m.b)
+Base.IteratorEltype(::Type{<:InterleaveBy}) = Base.EltypeUnknown()
 
-function Base.iterate(m::IMerge, (vsa,vsb) = (iterate(m.a),iterate(m.b)))
+function Base.iterate(m::InterleaveBy, (vsa,vsb) = (iterate(m.a),iterate(m.b)))
     if isnothing(vsa) && isnothing(vsb)
         return nothing
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -524,6 +524,13 @@ include("testing_macros.jl")
         @test collect(fv3) == Any[]
     end
 
+    @testset "merge" begin
+        itr = imerge(1:2:5,2:2:6, <=, identity, x->-x)
+        @test IteratorSize(itr) isa HasLength
+        @test length(itr) == 6
+        @test collect(itr) == [1,-2,3,-4,5,-6]
+    end
+
     @testset "traits overriding defaults" begin
         iters = [
             firstrest(1:10),

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -525,7 +525,7 @@ include("testing_macros.jl")
     end
 
     @testset "merge" begin
-        itr = imerge(1:2:5,2:2:6, <=, identity, x->-x)
+        itr = interleaveby(1:2:5,2:2:6, <=, identity, x->-x)
         @test IteratorSize(itr) isa HasLength
         @test length(itr) == 6
         @test collect(itr) == [1,-2,3,-4,5,-6]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -524,11 +524,16 @@ include("testing_macros.jl")
         @test collect(fv3) == Any[]
     end
 
-    @testset "merge" begin
-        itr = interleaveby(1:2:5,2:2:6, <=, identity, x->-x)
+    @testset "interleaveby" begin
+        itr = interleaveby(1:2:5,2:2:6)
         @test IteratorSize(itr) isa HasLength
         @test length(itr) == 6
-        @test collect(itr) == [1,-2,3,-4,5,-6]
+        @test collect(itr) == [1,2,3,4,5,6]
+        @test eltype(itr) == Int
+
+        itr_mixed = interleaveby(Returns(true), [1, 2], ['a', 'b', 'c', 'd'])
+        @test eltype(itr_mixed) == Union{Int, Char}
+        @test collect(itr_mixed) == [1, 2, 'a', 'b', 'c', 'd']
     end
 
     @testset "traits overriding defaults" begin


### PR DESCRIPTION
Adds the following function:

    imerge(a,b, predicate = <=, fa = identity, fb = identity)

Iterate over the union of `a` and `b`, merge-sort style.

Input:
 - `predicate(ak,bk) -> Bool`:
    Whether to pick the next element of `a` (true) or `b` (false).
 - `fa(ak)`, `fb(bk)`: Functions to apply to the picked elements

```jldoctest
julia> collect(imerge(1:2:5, 2:2:6, <=, identity, x->-x))
6-element Vector{Int64}:
  1
 -2
  3
 -4
  5
 -6
```

----------------

This PR is based on https://github.com/JuliaCollections/IterTools.jl/pull/86, so ideally we merge that one first. 