### PR TITLE
chunks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 docs/build/
 docs/site/
 .vscode/settings.json
+Manifest.toml

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 docs/build/
 docs/site/
+.vscode/settings.json

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+IterTools = "c8e1da08-722c-5040-9ed9-7db0dc04731e"
 
 [compat]
 Documenter = "0.27"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -8,7 +8,12 @@ end
 
 ## Installation
 
-Install this package with `Pkg.add("IterTools")`
+Install this package with 
+```julia-repl
+julia> import Pkg
+
+julia> Pkg.add("IterTools")
+```
 
 # Usage
 

--- a/src/IterTools.jl
+++ b/src/IterTools.jl
@@ -30,7 +30,8 @@ export
     takewhile,
     properties,
     propertyvalues,
-    fieldvalues
+    fieldvalues,
+    chunks
 
 function has_length(it)
     it_size = IteratorSize(it)
@@ -1026,5 +1027,14 @@ function iterate(fs::FieldValues, state=1)
 
     return (getfield(fs.x, state), state + 1)
 end
+
+#
+# Chunk splitter. 
+#
+# The following iterator splits the indices of AbstractArrays such that ranges can
+# be iterated in chunks, in batchs or scattered along the indices. This function 
+# can be useful for distributing jobs in parallel threaded loops.
+#
+include("./chunks.jl")
 
 end # module IterTools

--- a/src/chunks.jl
+++ b/src/chunks.jl
@@ -88,7 +88,6 @@ end
 
 import Base: length, eltype
 length(::Chunk{I,N}) where {I,N} = N
-eltype(::Chunk) = UnitRange{Int}
 
 import Base: firstindex, lastindex, getindex
 firstindex(::Chunk) = 1

--- a/src/chunks.jl
+++ b/src/chunks.jl
@@ -1,0 +1,184 @@
+"""
+
+    chunks(array::AbstractArray, nchunks::Int, type::Symbol=:batch)
+
+This function returns an iterable object that will split the *indices* of `array` into
+to `nchunks` chunks. `type` can be `:batch` or `:scatter`. It can be used to directly iterate
+over the chunks of a collection in a multi-threaded manner.
+
+## Eamples
+
+The iteration over `chunks` provides ranges that are continous sets of indices in 
+the `:batch` option (default), or indices that distant from each other if using `:scatter`.
+
+```julia-repl
+julia> using IterTools
+
+julia> x = rand(7);
+
+julia> Threads.@threads for (range, ichunk) in chunks(x, 3, :batch)
+           @show Threads.threadid(), range, ichunk
+       end
+(Threads.threadid(), range, ichunk) = (3, 1:3, 1)
+(Threads.threadid(), range, ichunk) = (8, 6:7, 3)
+(Threads.threadid(), range, ichunk) = (12, 4:5, 2)
+
+julia> Threads.@threads for (range, ichunk) in chunks(x, 3, :scatter)
+           @show Threads.threadid(), range, ichunk
+       end
+(Threads.threadid(), range, ichunk) = (5, 3:3:6, 3)
+(Threads.threadid(), range, ichunk) = (2, 1:3:7, 1)
+(Threads.threadid(), range, ichunk) = (3, 2:3:5, 2)
+```
+
+The ranges and chunk indices obtained in the iterations can be used to fine control
+multi-threaded updates of shared variables. For example, consider the simple parallel
+sum:
+
+```julia-repl
+julia> function sum_parallel(f, x; nchunks=Threads.nthreads())
+           s = fill(zero(eltype(x)), nchunks)
+           Threads.@threads for (xrange, ichunk) in chunks(x, nchunks)
+               for i in xrange
+                   s[ichunk] += f(x[i])
+               end
+           end
+           return sum(s)
+       end
+sum_parallel (generic function with 1 method)
+
+julia> x = rand(10^7);
+
+julia> sum_parallel(x -> log(x)^7, x; nchunks=12)
+-4.981040495460925e10
+```
+
+The fine control of chunk size can provide important performance benefits:
+```julia-repl
+julia> Threads.nthreads()
+12
+
+julia> @btime sum_parallel(x -> log(x)^7, $x; nchunks=12)
+  34.274 ms (77 allocations: 6.61 KiB)
+-4.981040495460925e10
+
+julia> @btime sum_parallel(x -> log(x)^7, $x; nchunks=128)
+  21.568 ms (77 allocations: 7.52 KiB)
+-4.981040495462144e10
+```
+
+"""
+function chunks end
+
+# Current chunks types
+const chunks_types = (:batch, :scatter)
+
+# Structure that carries the chunks data
+struct Chunk{I,N,T}
+    x::I
+    nchunks::Int
+end
+
+# Constructor for the chunks
+function chunks(x::AbstractArray, nchunks::Int, type=:batch)
+    nchunks >= 1 || throw(ArgumentError("nchunks must be >= 1"))
+    (type in chunks_types) || throw(ArgumentError("type must be one of $chunks_types"))
+    Chunk{typeof(x),nchunks,type}(x, nchunks)
+end
+
+import Base: length, eltype
+length(::Chunk{I,N}) where {I,N} = N
+eltype(::Chunk) = UnitRange{Int}
+
+import Base: firstindex, lastindex, getindex
+firstindex(::Chunk) = 1
+lastindex(::Chunk{I,N}) where {I,N} = N
+getindex(it::Chunk{I,N,T}, i::Int) where {I,N,T} = (chunks(it.x, i, it.nchunks, T), i)
+
+#
+# Iteration of the chunks
+#
+import Base: iterate
+function iterate(it::Chunk{I,N,T}, state=nothing) where {I,N,T}
+    if isnothing(state)
+        return ((chunks(it.x, 1, it.nchunks, T), 1), 1)
+    elseif state < it.nchunks
+        return ((chunks(it.x, state + 1, it.nchunks, T), state + 1), state + 1)
+    else
+        return nothing
+    end
+end
+
+#
+# This is the lower level function that receives `ichunk` as a parameter
+#
+"""
+    chunks(array::AbstractArray, ichunk::Int, nchunks::Int, type::Symbol=:batch)
+
+Lower level function that returns a range of indexes of `array`, given the number of chunks in
+which the array is to be split, `nchunks`, and the current chunk number `ichunk`. 
+
+# Extended help
+
+If `type == :batch`, the ranges are consecutive. If `type == :scatter`, the range
+is scattered over the array. 
+
+## Example
+
+For example, if we have an array of 7 elements, and the work on the elements is divided
+into 3 chunks, we have (using the default `type = :batch` option):
+
+```julia-repl
+julia> using ChunkSplitters
+
+julia> x = rand(7);
+
+julia> chunks(x, 1, 3)
+1:3
+
+julia> chunks(x, 2, 3)
+4:5
+
+julia> chunks(x, 3, 3)
+6:7
+```
+
+And using `type = :scatter`, we have:
+
+```julia-repl
+julia> chunks(x, 1, 3, :scatter)
+1:3:7
+
+julia> chunks(x, 2, 3, :scatter)
+2:3:5
+
+julia> chunks(x, 3, 3, :scatter)
+3:3:6
+```
+"""
+function chunks(array::AbstractArray, ichunk::Int, nchunks::Int, type::Symbol=:batch)
+    ichunk <= nchunks || throw(ArgumentError("ichunk must be less or equal to nchunks"))
+    return _chunks(array, ichunk, nchunks, Val(type))
+end
+
+#
+# function that splits the work in chunks that are scattered over the array
+#
+function _chunks(array, ichunk, nchunks, ::Val{:scatter})
+    first = (firstindex(array) - 1) + ichunk
+    last = lastindex(array)
+    step = nchunks
+    return first:step:last
+end
+
+#
+# function that splits the work in batches that are consecutive in the array
+#
+function _chunks(array, ichunk, nchunks, ::Val{:batch})
+    n = length(array)
+    n_per_chunk = div(n, nchunks)
+    n_remaining = n - nchunks * n_per_chunk
+    first = firstindex(array) + (ichunk - 1) * n_per_chunk + ifelse(ichunk <= n_remaining, ichunk - 1, n_remaining)
+    last = (first - 1) + n_per_chunk + ifelse(ichunk <= n_remaining, 1, 0)
+    return first:last
+end

--- a/src/chunks.jl
+++ b/src/chunks.jl
@@ -1,9 +1,9 @@
 """
 
-    chunks(array::AbstractArray, nchunks::Int, type::Symbol=:batch)
+    chunks(array::AbstractArray, nchunks::Int, chunk_type::Symbol=:batch)
 
 This function returns an iterable object that will split the *indices* of `array` into
-to `nchunks` chunks. `type` can be `:batch` or `:scatter`. It can be used to directly iterate
+to `nchunks` chunks. `chunk_type` can be `:batch` or `:scatter`. It can be used to directly iterate
 over the chunks of a collection in a multi-threaded manner.
 
 ## Eamples
@@ -80,10 +80,10 @@ struct Chunk{I,N,T}
 end
 
 # Constructor for the chunks
-function chunks(x::AbstractArray, nchunks::Int, type=:batch)
+function chunks(x::AbstractArray, nchunks::Int, chunk_type=:batch)
     nchunks >= 1 || throw(ArgumentError("nchunks must be >= 1"))
-    (type in chunks_types) || throw(ArgumentError("type must be one of $chunks_types"))
-    Chunk{typeof(x),nchunks,type}(x, nchunks)
+    (chunk_type in chunks_types) || throw(ArgumentError("chunk_type must be one of $chunks_types"))
+    Chunk{typeof(x),nchunks,chunk_type}(x, nchunks)
 end
 
 import Base: length, eltype
@@ -113,20 +113,20 @@ end
 # This is the lower level function that receives `ichunk` as a parameter
 #
 """
-    chunks(array::AbstractArray, ichunk::Int, nchunks::Int, type::Symbol=:batch)
+    chunks(array::AbstractArray, ichunk::Int, nchunks::Int, chunk_type::Symbol=:batch)
 
 Lower level function that returns a range of indexes of `array`, given the number of chunks in
 which the array is to be split, `nchunks`, and the current chunk number `ichunk`. 
 
 # Extended help
 
-If `type == :batch`, the ranges are consecutive. If `type == :scatter`, the range
+If `chunk_type == :batch`, the ranges are consecutive. If `chunk_type == :scatter`, the range
 is scattered over the array. 
 
 ## Example
 
 For example, if we have an array of 7 elements, and the work on the elements is divided
-into 3 chunks, we have (using the default `type = :batch` option):
+into 3 chunks, we have (using the default `chunk_type = :batch` option):
 
 ```julia-repl
 julia> using ChunkSplitters
@@ -143,7 +143,7 @@ julia> chunks(x, 3, 3)
 6:7
 ```
 
-And using `type = :scatter`, we have:
+And using `chunk_type = :scatter`, we have:
 
 ```julia-repl
 julia> chunks(x, 1, 3, :scatter)
@@ -156,9 +156,9 @@ julia> chunks(x, 3, 3, :scatter)
 3:3:6
 ```
 """
-function chunks(array::AbstractArray, ichunk::Int, nchunks::Int, type::Symbol=:batch)
+function chunks(array::AbstractArray, ichunk::Int, nchunks::Int, chunk_type::Symbol=:batch)
     ichunk <= nchunks || throw(ArgumentError("ichunk must be less or equal to nchunks"))
-    return _chunks(array, ichunk, nchunks, Val(type))
+    return _chunks(array, ichunk, nchunks, Val(chunk_type))
 end
 
 #

--- a/src/chunks.jl
+++ b/src/chunks.jl
@@ -100,7 +100,7 @@ getindex(it::Chunk{I,N,T}, i::Int) where {I,N,T} = (chunks(it.x, i, it.nchunks, 
 #
 import Base: iterate
 function iterate(it::Chunk{I,N,T}, state=nothing) where {I,N,T}
-    if isnothing(state)
+    if state === nothing
         return ((chunks(it.x, 1, it.nchunks, T), 1), 1)
     elseif state < it.nchunks
         return ((chunks(it.x, state + 1, it.nchunks, T), state + 1), state + 1)

--- a/src/chunks.jl
+++ b/src/chunks.jl
@@ -58,11 +58,11 @@ The fine control of chunk size can provide important performance benefits:
 julia> Threads.nthreads()
 12
 
-julia> @btime sum_parallel(x -> log(x)^7, $x; nchunks=12)
+julia> @btime sum_parallel(x -> log(x)^7, \$x; nchunks=12)
   34.274 ms (77 allocations: 6.61 KiB)
 -4.981040495460925e10
 
-julia> @btime sum_parallel(x -> log(x)^7, $x; nchunks=128)
+julia> @btime sum_parallel(x -> log(x)^7, \$x; nchunks=128)
   21.568 ms (77 allocations: 7.52 KiB)
 -4.981040495462144e10
 ```

--- a/src/chunks.jl
+++ b/src/chunks.jl
@@ -109,6 +109,9 @@ function iterate(it::Chunk{I,N,T}, state=nothing) where {I,N,T}
     end
 end
 
+import Base: collect
+collect(it::Chunk{I,N,T}) where {I,N,T} = [ (chunks(it.x, i, it.nchunks, T), i) for i in 1:N ]
+
 #
 # This is the lower level function that receives `ichunk` as a parameter
 #

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -525,59 +525,59 @@ include("testing_macros.jl")
         end
 
         @testset "chunks" begin
-            function test_chunks(; array_length, nchunks, type, result, return_ranges=false)
-                ranges = collect(chunks(rand(Int, array_length), i, nchunks, type) for i in 1:nchunks)
+            function test_chunks(; array_length, nchunks, chunk_type, result, return_ranges=false)
+                ranges = collect(chunks(rand(Int, array_length), i, nchunks, chunk_type) for i in 1:nchunks)
                 if return_ranges
                     return ranges
                 else
                     all(ranges .== result)
                 end
             end
-            function sum_parallel(x, nchunks, type)
+            function sum_parallel(x, nchunks, chunk_type)
                 s = fill(zero(eltype(x)), nchunks)
-                Threads.@threads for (range, ichunk) in chunks(x, nchunks, type)
+                Threads.@threads for (range, ichunk) in chunks(x, nchunks, chunk_type)
                     for i in range
                         s[ichunk] += x[i]
                     end
                 end
                 return sum(s)
             end
-            function test_sum(; array_length, nchunks, type)
+            function test_sum(; array_length, nchunks, chunk_type)
                 x = rand(array_length)
-                return sum_parallel(x, nchunks, type) ≈ sum(x)
+                return sum_parallel(x, nchunks, chunk_type) ≈ sum(x)
             end
             # test :scatter chunks
-            @test test_chunks(; array_length=1, nchunks=1, type=:scatter, result=[1:1])
-            @test test_chunks(; array_length=2, nchunks=1, type=:scatter, result=[1:2])
-            @test test_chunks(; array_length=2, nchunks=2, type=:scatter, result=[1:1, 2:2])
-            @test test_chunks(; array_length=3, nchunks=2, type=:scatter, result=[1:2:3, 2:2:2])
-            @test test_chunks(; array_length=7, nchunks=3, type=:scatter, result=[1:3:7, 2:3:5, 3:3:6])
-            @test test_chunks(; array_length=12, nchunks=4, type=:scatter, result=[1:4:9, 2:4:10, 3:4:11, 4:4:12])
-            @test test_chunks(; array_length=15, nchunks=4, type=:scatter, result=[1:4:13, 2:4:14, 3:4:15, 4:4:12])
-            @test test_sum(; array_length=1, nchunks=1, type=:scatter)
-            @test test_sum(; array_length=2, nchunks=1, type=:scatter)
-            @test test_sum(; array_length=2, nchunks=2, type=:scatter)
-            @test test_sum(; array_length=3, nchunks=2, type=:scatter)
-            @test test_sum(; array_length=7, nchunks=3, type=:scatter)
-            @test test_sum(; array_length=12, nchunks=4, type=:scatter)
-            @test test_sum(; array_length=15, nchunks=4, type=:scatter)
-            @test test_sum(; array_length=117, nchunks=4, type=:scatter)
+            @test test_chunks(; array_length=1, nchunks=1, chunk_type=:scatter, result=[1:1])
+            @test test_chunks(; array_length=2, nchunks=1, chunk_type=:scatter, result=[1:2])
+            @test test_chunks(; array_length=2, nchunks=2, chunk_type=:scatter, result=[1:1, 2:2])
+            @test test_chunks(; array_length=3, nchunks=2, chunk_type=:scatter, result=[1:2:3, 2:2:2])
+            @test test_chunks(; array_length=7, nchunks=3, chunk_type=:scatter, result=[1:3:7, 2:3:5, 3:3:6])
+            @test test_chunks(; array_length=12, nchunks=4, chunk_type=:scatter, result=[1:4:9, 2:4:10, 3:4:11, 4:4:12])
+            @test test_chunks(; array_length=15, nchunks=4, chunk_type=:scatter, result=[1:4:13, 2:4:14, 3:4:15, 4:4:12])
+            @test test_sum(; array_length=1, nchunks=1, chunk_type=:scatter)
+            @test test_sum(; array_length=2, nchunks=1, chunk_type=:scatter)
+            @test test_sum(; array_length=2, nchunks=2, chunk_type=:scatter)
+            @test test_sum(; array_length=3, nchunks=2, chunk_type=:scatter)
+            @test test_sum(; array_length=7, nchunks=3, chunk_type=:scatter)
+            @test test_sum(; array_length=12, nchunks=4, chunk_type=:scatter)
+            @test test_sum(; array_length=15, nchunks=4, chunk_type=:scatter)
+            @test test_sum(; array_length=117, nchunks=4, chunk_type=:scatter)
             # test :batch chunks
-            @test test_chunks(; array_length=1, nchunks=1, type=:batch, result=[1:1])
-            @test test_chunks(; array_length=2, nchunks=1, type=:batch, result=[1:2])
-            @test test_chunks(; array_length=2, nchunks=2, type=:batch, result=[1:1, 2:2])
-            @test test_chunks(; array_length=3, nchunks=2, type=:batch, result=[1:2, 3:3])
-            @test test_chunks(; array_length=7, nchunks=3, type=:batch, result=[1:3, 4:5, 6:7])
-            @test test_chunks(; array_length=12, nchunks=4, type=:batch, result=[1:3, 4:6, 7:9, 10:12])
-            @test test_chunks(; array_length=15, nchunks=4, type=:batch, result=[1:4, 5:8, 9:12, 13:15])
-            @test test_sum(; array_length=1, nchunks=1, type=:batch)
-            @test test_sum(; array_length=2, nchunks=1, type=:batch)
-            @test test_sum(; array_length=2, nchunks=2, type=:batch)
-            @test test_sum(; array_length=3, nchunks=2, type=:batch)
-            @test test_sum(; array_length=7, nchunks=3, type=:batch)
-            @test test_sum(; array_length=12, nchunks=4, type=:batch)
-            @test test_sum(; array_length=15, nchunks=4, type=:batch)
-            @test test_sum(; array_length=117, nchunks=4, type=:batch)
+            @test test_chunks(; array_length=1, nchunks=1, chunk_type=:batch, result=[1:1])
+            @test test_chunks(; array_length=2, nchunks=1, chunk_type=:batch, result=[1:2])
+            @test test_chunks(; array_length=2, nchunks=2, chunk_type=:batch, result=[1:1, 2:2])
+            @test test_chunks(; array_length=3, nchunks=2, chunk_type=:batch, result=[1:2, 3:3])
+            @test test_chunks(; array_length=7, nchunks=3, chunk_type=:batch, result=[1:3, 4:5, 6:7])
+            @test test_chunks(; array_length=12, nchunks=4, chunk_type=:batch, result=[1:3, 4:6, 7:9, 10:12])
+            @test test_chunks(; array_length=15, nchunks=4, chunk_type=:batch, result=[1:4, 5:8, 9:12, 13:15])
+            @test test_sum(; array_length=1, nchunks=1, chunk_type=:batch)
+            @test test_sum(; array_length=2, nchunks=1, chunk_type=:batch)
+            @test test_sum(; array_length=2, nchunks=2, chunk_type=:batch)
+            @test test_sum(; array_length=3, nchunks=2, chunk_type=:batch)
+            @test test_sum(; array_length=7, nchunks=3, chunk_type=:batch)
+            @test test_sum(; array_length=12, nchunks=4, chunk_type=:batch)
+            @test test_sum(; array_length=15, nchunks=4, chunk_type=:batch)
+            @test test_sum(; array_length=117, nchunks=4, chunk_type=:batch)
         end
 
         @testset "traits overriding defaults" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -580,6 +580,13 @@ include("testing_macros.jl")
             @test test_sum(; array_length=12, nchunks=4, chunk_type=:batch)
             @test test_sum(; array_length=15, nchunks=4, chunk_type=:batch)
             @test test_sum(; array_length=117, nchunks=4, chunk_type=:batch)
+            # collect
+            @test collect(chunks(1:7, 3, :batch)) == [(1:3,1), (4:5,2), (6:7,3)]
+            @test collect(chunks(1:7, 3, :scatter)) == [(1:3:7, 1), (2:3:5, 2), (3:3:6, 3)]
+            @test length(chunks(1:7,3)) == 3
+            @test firstindex(chunks(1:7,3)) == 1
+            @test lastindex(chunks(1:7,3)) == 3
+            @test getindex(chunks(1:7,3),2) == (4:5, 2)
         end
 
         @testset "traits overriding defaults" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,550 +9,606 @@ include("testing_macros.jl")
 
 
 @testset "IterTools" begin
-@testset "iterators" begin
-    @testset "firstrest" begin
-        # Ranges/generators have different rest states vs array/tuples
-        test_base_cases = [
-            (1:1, 1),
-            (1:3, 1),
-            ([1], 2),
-            ([1, 2, 3], 2),
-            ((1,), 2),
-            ((1, 2, 3), 2),
-            ((i for i in 1:1), 1),
-            ((i for i in 1:3), 1),
-        ]
-        @testset "$xs" for (xs, s) in test_base_cases
-            f, r = firstrest(xs)
-            @test f == first(xs)
-            @test collect(r) == collect(Iterators.rest(xs, s))
-        end
-
-        test_empty_cases = [
-            (1:0, 1),
-            (Int[], 2),
-            ((), 2),
-            ((i for i in 1:0), 1),
-        ]
-
-        @testset "$xs" for (xs, s) in test_empty_cases
-            @test_throws ArgumentError firstrest(xs)
-        end
-    end
-
-    @testset "takestrict" begin
-        itr = 1:10
-        take_itr = takestrict(itr, 5)
-        @test eltype(take_itr) == Int
-        @test IteratorEltype(take_itr) isa HasEltype
-        @test IteratorSize(take_itr) isa HasLength
-        @test length(take_itr) == 5
-        @test collect(take_itr) == collect(1:5)
-
-    end
-
-    @testset "ncycle" begin
-        ncy1 = ncycle(0:3,3)
-
-        i = 0
-        for j in ncy1
-            @test j == i % 4
-            i += 1
-        end
-
-        @test eltype(ncy1) == Int
-        i = 0
-        for j in collect(ncy1)
-            @test j == i % 4
-            i += 1
-        end
-    end
-
-    @testset "repeatedly" begin
-        i = 0
-        for j = repeatedly(() -> 1, 10)
-            @test j == 1
-            i += 1
-        end
-        @test i == 10
-        for j = repeatedly(() -> 1)
-            @test j == 1
-            i += 1
-            i <= 10 || break
-        end
-    end
-
-    @testset "distinct" begin
-        x = [5, 2, 2, 1, 2, 1, 1, 2, 4, 2]
-        unique_x = unique(x)
-        di0 = distinct(x)
-        @test eltype(di0) == Int
-        @test collect(di0) == unique_x
-
-        # repeated operations on the same Distinct iterator should function identically
-        @test collect(di0) == unique_x
-    end
-
-    @testset "partition" begin
-        pa0 = partition(take(countfrom(1), 6), 2)
-        @test eltype(pa0) == Tuple{Int, Int}
-        @test length(pa0) == 3
-        @test IteratorSize(pa0) isa HasLength
-        @test collect(pa0) == [(1,2), (3,4), (5,6)]
-
-        pa1 = partition(take(countfrom(1), 4), 2, 1)
-        @test eltype(pa1) == Tuple{Int, Int}
-        @test length(pa1) == 3
-        @test collect(pa1) == [(1,2), (2,3), (3,4)]
-
-        pa2 = partition(take(countfrom(1), 8), 2, 3)
-        @test eltype(pa2) == Tuple{Int, Int}
-        @test length(pa2) == 3
-        @test collect(pa2) == [(1,2), (4,5), (7,8)]
-
-        pa3 = partition(take(countfrom(1), 0), 2, 1)
-        @test eltype(pa3) == Tuple{Int, Int}
-        @test length(pa3) == 0
-        @test collect(pa3) == []
-
-        pa4 = partition(1:8, 1)
-        @test eltype(pa4) == Tuple{Int}
-        @test length(pa4) == 8
-        @test collect(pa4) == [(1,), (2,), (3,), (4,), (5,), (6,), (7,), (8,)]
-
-        @test_throws ArgumentError partition(take(countfrom(1), 8), 2, 0)
-
-        # test with a SizeUnknown iterator
-        pa5 = partition(takewhile(x -> x ≤ 10, countfrom(1)), 1, 1)
-        @test_throws MethodError length(pa5)
-        @test IteratorSize(pa5) isa SizeUnknown
-        @test length(collect(pa5)) == 10
-
-        # test with a IsInfinite iterator
-        pa5 = partition(countfrom(1), 1, 1)
-        @test_throws MethodError length(pa5)
-        @test IteratorSize(pa5) isa IsInfinite
-
-        # Test https://github.com/JuliaCollections/IterTools.jl/issues/39
-        _sliding_pairs_type(a) = eltype(IterTools.partition(a, 2, 1))
-        @inferred _sliding_pairs_type([1,2,3])
-    end
-
-    @testset "imap" begin
-        function test_imap(expected, input...)
-            result = collect(imap(+, input...))
-            @test result == expected
-        end
-
-        @testset "empty arrays" begin
-            test_imap(
-                Any[],
-                []
-            )
-
-            test_imap(
-                Any[],
-                Union{}[]
-            )
-        end
-
-        @testset "simple operation" begin
-            test_imap(
-                Any[1,2,3],
-                [1,2,3]
-            )
-        end
-
-        @testset "multiple arguments" begin
-            test_imap(
-                Any[5,7,9],
-                [1,2,3],
-                [4,5,6]
-            )
-        end
-
-        @testset "different-length arguments" begin
-            test_imap(
-                Any[2,4,6],
-                [1,2,3],
-                countfrom(1)
-            )
-        end
-    end
-
-
-    @testset "groupby" begin
-        function test_groupby(input, expected)
-            result = collect(groupby(x -> x[1], input))
-            @test result == expected
-        end
-
-        @testset "empty arrays" begin
-            test_groupby(
-                [],
-                Any[]
-            )
-
-            test_groupby(
-                Union{}[],
-                Any[]
-            )
-        end
-
-        @testset "singletons" begin
-            test_groupby(
-                ["xxx"],
-                Any[["xxx"]]
-            )
-        end
-
-        @testset "typical operation" begin
-            test_groupby(
-                ["face", "foo", "bar", "book", "baz"],
-                Any[["face", "foo"], ["bar", "book", "baz"]]
-            )
-        end
-
-        @testset "trailing singletons" begin
-            test_groupby(
-                ["face", "foo", "bar", "book", "baz", "xxx"],
-                Any[["face", "foo"], ["bar", "book", "baz"], ["xxx"]]
-            )
-        end
-
-        @testset "leading singletons" begin
-            test_groupby(
-                ["xxx", "face", "foo", "bar", "book", "baz"],
-                Any[["xxx"], ["face", "foo"], ["bar", "book", "baz"]]
-            )
-        end
-
-        @testset "middle singletons" begin
-            test_groupby(
-                ["face", "foo", "xxx", "bar", "book", "baz"],
-                Any[["face", "foo"], ["xxx"], ["bar", "book", "baz"]]
-            )
-        end
-    end
-
-    @testset "subsets" begin
-        @testset "all lengths" begin
-            s0 = subsets(Any[])
-            @test eltype(eltype(s0)) == Any
-            @test collect(s0) == Vector{Any}[Any[]]
-
-            s1 = subsets([:a])
-            @test eltype(eltype(s1)) == Symbol
-            @test collect(s1) == Vector{Symbol}[Symbol[], Symbol[:a]]
-
-            s2 = subsets([:a, :b, :c])
-            @test eltype(eltype(s2)) == Symbol
-            @test collect(s2) == Vector{Symbol}[
-                Symbol[], Symbol[:a], Symbol[:b], Symbol[:a, :b], Symbol[:c],
-                Symbol[:a, :c], Symbol[:b, :c], Symbol[:a, :b, :c],
+    @testset "iterators" begin
+        @testset "firstrest" begin
+            # Ranges/generators have different rest states vs array/tuples
+            test_base_cases = [
+                (1:1, 1),
+                (1:3, 1),
+                ([1], 2),
+                ([1, 2, 3], 2),
+                ((1,), 2),
+                ((1, 2, 3), 2),
+                ((i for i in 1:1), 1),
+                ((i for i in 1:3), 1),
             ]
-        end
-
-        @testset "specific length" begin
-            sk0 = subsets(Any[],0)
-            @test eltype(eltype(sk0)) == Any
-            @test collect(sk0) == Vector{Any}[Any[]]
-
-            sk1 = subsets([:a, :b, :c], 1)
-            @test eltype(eltype(sk1)) == Symbol
-            @test collect(sk1) == Vector{Symbol}[Symbol[:a], Symbol[:b], Symbol[:c]]
-
-            sk2 = subsets([:a, :b, :c], 2)
-            @test eltype(eltype(sk2)) == Symbol
-            @test collect(sk2) == Vector{Symbol}[Symbol[:a,:b], Symbol[:a,:c], Symbol[:b,:c]]
-
-            sk3 = subsets([:a, :b, :c], 3)
-            @test eltype(eltype(sk3)) == Symbol
-            @test collect(sk3) == Vector{Symbol}[Symbol[:a,:b,:c]]
-
-            sk4 = subsets([:a, :b, :c], 4)
-            @test eltype(eltype(sk4)) == Symbol
-            @test collect(sk4) == Vector{Symbol}[]
-
-            @testset for i in 1:5
-                sk5 = subsets(collect(1:4), i)
-                @test eltype(eltype(sk5)) == Int
-                @test length(collect(sk5)) == binomial(4, i)
+            @testset "$xs" for (xs, s) in test_base_cases
+                f, r = firstrest(xs)
+                @test f == first(xs)
+                @test collect(r) == collect(Iterators.rest(xs, s))
             end
 
-            @testset "implicit conversions" begin
-                sk10 = subsets(1:4, 3)
-                @test eltype(eltype(sk10)) == Int
-                @test length(collect(sk10)) == binomial(4, 3)
+            test_empty_cases = [
+                (1:0, 1),
+                (Int[], 2),
+                ((), 2),
+                ((i for i in 1:0), 1),
+            ]
 
-                sk11 = subsets(1:3, Int32(2))
-                @test eltype(eltype(sk11)) == Int
-                @test length(collect(sk11)) == binomial(3, 2)
+            @testset "$xs" for (xs, s) in test_empty_cases
+                @test_throws ArgumentError firstrest(xs)
             end
         end
 
-        @testset "specific static length" begin
-            sk0 = subsets([:a, :b, :c], Val{0}())
-            @test collect(sk0) == [()]
+        @testset "takestrict" begin
+            itr = 1:10
+            take_itr = takestrict(itr, 5)
+            @test eltype(take_itr) == Int
+            @test IteratorEltype(take_itr) isa HasEltype
+            @test IteratorSize(take_itr) isa HasLength
+            @test length(take_itr) == 5
+            @test collect(take_itr) == collect(1:5)
 
-            sk1 = subsets([:a, :b, :c], Val{1}())
-            @test eltype(eltype(sk1)) == Symbol
-            @test collect(sk1) == [(:a,), (:b,), (:c,)]
+        end
 
-            sk2 = subsets([:a, :b, :c], Val{2}())
-            @test eltype(eltype(sk2)) == Symbol
-            @test collect(sk2) == [(:a, :b), (:a, :c), (:b, :c)]
+        @testset "ncycle" begin
+            ncy1 = ncycle(0:3, 3)
 
-            sk3 = subsets([:a, :b, :c], Val{3}())
-            @test eltype(eltype(sk3)) == Symbol
-            @test collect(sk3) == [(:a, :b, :c)]
-
-            sk4 = subsets([:a, :b, :c], Val{4}())
-            @test eltype(eltype(sk4)) == Symbol
-            @test collect(sk4) == []
-
-            sk5 = subsets([:a, :b, :c], Val{5}())
-            @test eltype(eltype(sk5)) == Symbol
-            @test collect(sk5) == []
-
-            @testset for i in 1:6
-                sk5 = subsets(collect(1:4), Val{i}())
-                @test eltype(eltype(sk5)) == Int
-                @test length(collect(sk5)) == binomial(4, i)
+            i = 0
+            for j in ncy1
+                @test j == i % 4
+                i += 1
             end
 
-            function collect_pairs(x)
-                p = Vector{NTuple{2, eltype(x)}}(undef, binomial(length(x), 2))
-                idx = 1
-                for i = 1:length(x)
-                    for j = i+1:length(x)
-                        p[idx] = (x[i], x[j])
-                        idx += 1
+            @test eltype(ncy1) == Int
+            i = 0
+            for j in collect(ncy1)
+                @test j == i % 4
+                i += 1
+            end
+        end
+
+        @testset "repeatedly" begin
+            i = 0
+            for j = repeatedly(() -> 1, 10)
+                @test j == 1
+                i += 1
+            end
+            @test i == 10
+            for j = repeatedly(() -> 1)
+                @test j == 1
+                i += 1
+                i <= 10 || break
+            end
+        end
+
+        @testset "distinct" begin
+            x = [5, 2, 2, 1, 2, 1, 1, 2, 4, 2]
+            unique_x = unique(x)
+            di0 = distinct(x)
+            @test eltype(di0) == Int
+            @test collect(di0) == unique_x
+
+            # repeated operations on the same Distinct iterator should function identically
+            @test collect(di0) == unique_x
+        end
+
+        @testset "partition" begin
+            pa0 = partition(take(countfrom(1), 6), 2)
+            @test eltype(pa0) == Tuple{Int,Int}
+            @test length(pa0) == 3
+            @test IteratorSize(pa0) isa HasLength
+            @test collect(pa0) == [(1, 2), (3, 4), (5, 6)]
+
+            pa1 = partition(take(countfrom(1), 4), 2, 1)
+            @test eltype(pa1) == Tuple{Int,Int}
+            @test length(pa1) == 3
+            @test collect(pa1) == [(1, 2), (2, 3), (3, 4)]
+
+            pa2 = partition(take(countfrom(1), 8), 2, 3)
+            @test eltype(pa2) == Tuple{Int,Int}
+            @test length(pa2) == 3
+            @test collect(pa2) == [(1, 2), (4, 5), (7, 8)]
+
+            pa3 = partition(take(countfrom(1), 0), 2, 1)
+            @test eltype(pa3) == Tuple{Int,Int}
+            @test length(pa3) == 0
+            @test collect(pa3) == []
+
+            pa4 = partition(1:8, 1)
+            @test eltype(pa4) == Tuple{Int}
+            @test length(pa4) == 8
+            @test collect(pa4) == [(1,), (2,), (3,), (4,), (5,), (6,), (7,), (8,)]
+
+            @test_throws ArgumentError partition(take(countfrom(1), 8), 2, 0)
+
+            # test with a SizeUnknown iterator
+            pa5 = partition(takewhile(x -> x ≤ 10, countfrom(1)), 1, 1)
+            @test_throws MethodError length(pa5)
+            @test IteratorSize(pa5) isa SizeUnknown
+            @test length(collect(pa5)) == 10
+
+            # test with a IsInfinite iterator
+            pa5 = partition(countfrom(1), 1, 1)
+            @test_throws MethodError length(pa5)
+            @test IteratorSize(pa5) isa IsInfinite
+
+            # Test https://github.com/JuliaCollections/IterTools.jl/issues/39
+            _sliding_pairs_type(a) = eltype(IterTools.partition(a, 2, 1))
+            @inferred _sliding_pairs_type([1, 2, 3])
+        end
+
+        @testset "imap" begin
+            function test_imap(expected, input...)
+                result = collect(imap(+, input...))
+                @test result == expected
+            end
+
+            @testset "empty arrays" begin
+                test_imap(
+                    Any[],
+                    []
+                )
+
+                test_imap(
+                    Any[],
+                    Union{}[]
+                )
+            end
+
+            @testset "simple operation" begin
+                test_imap(
+                    Any[1, 2, 3],
+                    [1, 2, 3]
+                )
+            end
+
+            @testset "multiple arguments" begin
+                test_imap(
+                    Any[5, 7, 9],
+                    [1, 2, 3],
+                    [4, 5, 6]
+                )
+            end
+
+            @testset "different-length arguments" begin
+                test_imap(
+                    Any[2, 4, 6],
+                    [1, 2, 3],
+                    countfrom(1)
+                )
+            end
+        end
+
+
+        @testset "groupby" begin
+            function test_groupby(input, expected)
+                result = collect(groupby(x -> x[1], input))
+                @test result == expected
+            end
+
+            @testset "empty arrays" begin
+                test_groupby(
+                    [],
+                    Any[]
+                )
+
+                test_groupby(
+                    Union{}[],
+                    Any[]
+                )
+            end
+
+            @testset "singletons" begin
+                test_groupby(
+                    ["xxx"],
+                    Any[["xxx"]]
+                )
+            end
+
+            @testset "typical operation" begin
+                test_groupby(
+                    ["face", "foo", "bar", "book", "baz"],
+                    Any[["face", "foo"], ["bar", "book", "baz"]]
+                )
+            end
+
+            @testset "trailing singletons" begin
+                test_groupby(
+                    ["face", "foo", "bar", "book", "baz", "xxx"],
+                    Any[["face", "foo"], ["bar", "book", "baz"], ["xxx"]]
+                )
+            end
+
+            @testset "leading singletons" begin
+                test_groupby(
+                    ["xxx", "face", "foo", "bar", "book", "baz"],
+                    Any[["xxx"], ["face", "foo"], ["bar", "book", "baz"]]
+                )
+            end
+
+            @testset "middle singletons" begin
+                test_groupby(
+                    ["face", "foo", "xxx", "bar", "book", "baz"],
+                    Any[["face", "foo"], ["xxx"], ["bar", "book", "baz"]]
+                )
+            end
+        end
+
+        @testset "subsets" begin
+            @testset "all lengths" begin
+                s0 = subsets(Any[])
+                @test eltype(eltype(s0)) == Any
+                @test collect(s0) == Vector{Any}[Any[]]
+
+                s1 = subsets([:a])
+                @test eltype(eltype(s1)) == Symbol
+                @test collect(s1) == Vector{Symbol}[Symbol[], Symbol[:a]]
+
+                s2 = subsets([:a, :b, :c])
+                @test eltype(eltype(s2)) == Symbol
+                @test collect(s2) == Vector{Symbol}[
+                    Symbol[], Symbol[:a], Symbol[:b], Symbol[:a, :b], Symbol[:c],
+                    Symbol[:a, :c], Symbol[:b, :c], Symbol[:a, :b, :c],
+                ]
+            end
+
+            @testset "specific length" begin
+                sk0 = subsets(Any[], 0)
+                @test eltype(eltype(sk0)) == Any
+                @test collect(sk0) == Vector{Any}[Any[]]
+
+                sk1 = subsets([:a, :b, :c], 1)
+                @test eltype(eltype(sk1)) == Symbol
+                @test collect(sk1) == Vector{Symbol}[Symbol[:a], Symbol[:b], Symbol[:c]]
+
+                sk2 = subsets([:a, :b, :c], 2)
+                @test eltype(eltype(sk2)) == Symbol
+                @test collect(sk2) == Vector{Symbol}[Symbol[:a, :b], Symbol[:a, :c], Symbol[:b, :c]]
+
+                sk3 = subsets([:a, :b, :c], 3)
+                @test eltype(eltype(sk3)) == Symbol
+                @test collect(sk3) == Vector{Symbol}[Symbol[:a, :b, :c]]
+
+                sk4 = subsets([:a, :b, :c], 4)
+                @test eltype(eltype(sk4)) == Symbol
+                @test collect(sk4) == Vector{Symbol}[]
+
+                @testset for i in 1:5
+                    sk5 = subsets(collect(1:4), i)
+                    @test eltype(eltype(sk5)) == Int
+                    @test length(collect(sk5)) == binomial(4, i)
+                end
+
+                @testset "implicit conversions" begin
+                    sk10 = subsets(1:4, 3)
+                    @test eltype(eltype(sk10)) == Int
+                    @test length(collect(sk10)) == binomial(4, 3)
+
+                    sk11 = subsets(1:3, Int32(2))
+                    @test eltype(eltype(sk11)) == Int
+                    @test length(collect(sk11)) == binomial(3, 2)
+                end
+            end
+
+            @testset "specific static length" begin
+                sk0 = subsets([:a, :b, :c], Val{0}())
+                @test collect(sk0) == [()]
+
+                sk1 = subsets([:a, :b, :c], Val{1}())
+                @test eltype(eltype(sk1)) == Symbol
+                @test collect(sk1) == [(:a,), (:b,), (:c,)]
+
+                sk2 = subsets([:a, :b, :c], Val{2}())
+                @test eltype(eltype(sk2)) == Symbol
+                @test collect(sk2) == [(:a, :b), (:a, :c), (:b, :c)]
+
+                sk3 = subsets([:a, :b, :c], Val{3}())
+                @test eltype(eltype(sk3)) == Symbol
+                @test collect(sk3) == [(:a, :b, :c)]
+
+                sk4 = subsets([:a, :b, :c], Val{4}())
+                @test eltype(eltype(sk4)) == Symbol
+                @test collect(sk4) == []
+
+                sk5 = subsets([:a, :b, :c], Val{5}())
+                @test eltype(eltype(sk5)) == Symbol
+                @test collect(sk5) == []
+
+                @testset for i in 1:6
+                    sk5 = subsets(collect(1:4), Val{i}())
+                    @test eltype(eltype(sk5)) == Int
+                    @test length(collect(sk5)) == binomial(4, i)
+                end
+
+                function collect_pairs(x)
+                    p = Vector{NTuple{2,eltype(x)}}(undef, binomial(length(x), 2))
+                    idx = 1
+                    for i = 1:length(x)
+                        for j = i+1:length(x)
+                            p[idx] = (x[i], x[j])
+                            idx += 1
+                        end
+                    end
+                    return p
+                end
+                @testset for n = 1:10
+                    @test collect(subsets(1:n, Val{2}())) == collect_pairs(1:n)
+                end
+            end
+        end
+
+        @testset "nth" begin
+            @testset for xs in Any[
+                [1, 2, 3],
+                1:3,
+                reshape(1:3, 3, 1),
+                sparse(reshape(1:3, 1, 3)),
+            ]
+                @test nth(xs, 3) == 3
+                @test_throws BoundsError nth(xs, 0)
+                @test_throws BoundsError nth(xs, 4)
+            end
+
+            @testset for xs in Any[take(1:3, 3), drop(-1:3, 2)]
+                @test nth(xs, 3) == 3
+                @test_throws BoundsError nth(xs, 0)
+            end
+
+            s = subsets([1, 2, 3])
+            @test_throws BoundsError nth(s, 0)
+            @test_throws BoundsError nth(s, length(s) + 1)
+
+            # #100
+            @test nth(drop(repeatedly(() -> 1), 1), 1) == 1
+        end
+
+
+        @testset "takenth" begin
+            tn0 = takenth(Any[], 10)
+            @test eltype(tn0) == Any
+            @test collect(tn0) == Any[]
+
+            tn1 = takenth(Int[], 10)
+            @test eltype(tn1) == Int
+            @test collect(tn1) == Int[]
+
+            @test_throws ArgumentError takenth([], 0)
+
+            tn2 = takenth(10:20, 3)
+            @test eltype(tn2) == Int
+            @test collect(tn2) == [12, 15, 18]
+
+            tn3 = takenth(10:20, 1)
+            @test eltype(tn3) == Int
+            @test collect(tn3) == collect(10:20)
+        end
+
+
+        @testset "iterated" begin
+            times_called = Ref(0)
+
+            function iter_func(x)
+                times_called[] += 1
+                x + 1
+            end
+
+            itd = iterated(iter_func, 3)
+            @test IteratorSize(itd) isa IsInfinite
+            @test collect(take(itd, 4)) == 3:6
+            # the first item is just the seed so iter_func isn't called
+            @test times_called[] == 3
+        end
+
+
+        @testset "peekiter" begin
+            pi0 = peekiter(1:10)
+            @test IteratorEltype(pi0) isa HasEltype
+            @test eltype(pi0) == Int
+            @test collect(pi0) == collect(1:10)
+
+            pi1 = peekiter([])
+            @test IteratorEltype(pi1) isa HasEltype
+            @test eltype(pi1) == eltype([])
+            @test collect(pi1) == collect([])
+
+            it = peekiter([:a, :b, :c])
+            @test IteratorEltype(it) isa HasEltype
+            @test eltype(it) == Symbol
+            x, s = iterate(it)
+            @test x == :a
+            @test peek(it, s) == Some(:b)
+
+            @test iterate(peekiter([])) === nothing
+
+            it = peekiter(1:10)
+            x, s = iterate(it)
+            @test x == 1
+            @test peek(it, s) == Some(2)
+
+            it = peekiter(1:1)
+            x, s = iterate(it)
+            @test x == 1
+            @test peek(it, s) === nothing
+            @test iterate(it, s) === nothing
+        end
+
+        @testset "ivec" begin
+            irange = 1:12
+            vector = collect(irange)
+            @test collect(ivec(irange)) == vector
+            @test collect(ivec(vector)) == vector
+
+            matrix = reshape(vector, 3, 4)
+            @test collect(ivec(matrix)) == vector
+
+            ndarray = reshape(vector, 2, 2, 3)
+            @test collect(ivec(ndarray)) == vector
+        end
+
+        @testset "flagfirst" begin
+            v = rand(1:10, 20)
+            Tv = typeof(v)
+            ff = flagfirst(v)
+            Tff = typeof(ff)
+            @test IteratorEltype(Tff) ≡ IteratorEltype(v)
+            @test eltype(Tff) ≡ Tuple{Bool,eltype(v)}
+            @test collect(flagfirst(v)) ==
+                  collect(zip(vcat([true], fill(false, length(v) - 1)), v))
+
+            @test collect(flagfirst(Int[])) == Tuple{Bool,Int}[]
+        end
+
+        @testset "takewhile" begin
+            @test collect(takewhile(x -> x^2 < 10, 1:10)) == Any[1, 2, 3]
+            @test collect(takewhile(x -> x^2 < 10, Iterators.countfrom(1))) == Any[1, 2, 3]
+            @test collect(takewhile(x -> x^2 < 10, 5:10)) == Any[]
+            @test collect(takewhile(x -> true, 5:10)) == collect(5:10)
+        end
+
+        @testset "properties" begin
+            p1 = properties(1 + 2im)
+            @test IteratorEltype(p1) isa HasEltype
+            @test eltype(p1) == Any
+            @test IteratorSize(p1) isa HasLength
+            @test length(p1) == 2
+            @test collect(p1) == Any[(:re, 1), (:im, 2)]
+
+            ntp = (a="", b=1, c=2.0)
+            p2 = properties(ntp)
+            @test collect(p2) == Tuple.(collect(pairs(ntp)))
+
+            # HasLength used as an example no-field struct
+            p3 = properties(HasLength())
+            @test collect(p3) == Any[]
+        end
+
+        @testset "propertyvalues" begin
+            pv1 = propertyvalues(1 + 2im)
+            @test IteratorEltype(pv1) isa HasEltype
+            @test eltype(pv1) == Any
+            @test IteratorSize(pv1) isa HasLength
+            @test length(pv1) == 2
+            @test collect(pv1) == Any[1, 2]
+
+            tp = ("", 1, 2.0)
+            pv2 = propertyvalues(tp)
+
+            # getproperty for tuples wasn't introduced until 1.2
+            # https://github.com/JuliaLang/julia/pull/31324
+            @static if VERSION < v"1.2.0-DEV.460"
+                @test_broken collect(pv2) == collect(tp)
+            else
+                @test collect(pv2) == collect(tp)
+            end
+
+            # HasLength used as an example no-field struct
+            pv3 = propertyvalues(HasLength())
+            @test collect(pv3) == Any[]
+        end
+
+        @testset "fieldvalues" begin
+            fv1 = fieldvalues(1 + 2im)
+            @test IteratorEltype(fv1) isa HasEltype
+            @test eltype(fv1) == Any
+            @test IteratorSize(fv1) isa HasLength
+            @test length(fv1) == 2
+            @test collect(fv1) == Any[1, 2]
+
+            tp = ("", 1, 2.0)
+            fv2 = fieldvalues(tp)
+            @test collect(fv2) == collect(tp)
+
+            # HasLength used as an example no-field struct
+            fv3 = fieldvalues(HasLength())
+            @test collect(fv3) == Any[]
+        end
+
+        @testset "chunks" begin
+            function test_chunks(; array_length, nchunks, type, result, return_ranges=false)
+                ranges = collect(chunks(rand(Int, array_length), i, nchunks, type) for i in 1:nchunks)
+                if return_ranges
+                    return ranges
+                else
+                    all(ranges .== result)
+                end
+            end
+            function sum_parallel(x, nchunks, type)
+                s = fill(zero(eltype(x)), nchunks)
+                Threads.@threads for (range, ichunk) in chunks(x, nchunks, type)
+                    for i in range
+                        s[ichunk] += x[i]
                     end
                 end
-                return p
+                return sum(s)
             end
-            @testset for n = 1:10
-                @test collect(subsets(1:n, Val{2}())) == collect_pairs(1:n)
+            function test_sum(; array_length, nchunks, type)
+                x = rand(array_length)
+                return sum_parallel(x, nchunks, type) ≈ sum(x)
+            end
+            # test :scatter chunks
+            @test test_chunks(; array_length=1, nchunks=1, type=:scatter, result=[1:1])
+            @test test_chunks(; array_length=2, nchunks=1, type=:scatter, result=[1:2])
+            @test test_chunks(; array_length=2, nchunks=2, type=:scatter, result=[1:1, 2:2])
+            @test test_chunks(; array_length=3, nchunks=2, type=:scatter, result=[1:2:3, 2:2:2])
+            @test test_chunks(; array_length=7, nchunks=3, type=:scatter, result=[1:3:7, 2:3:5, 3:3:6])
+            @test test_chunks(; array_length=12, nchunks=4, type=:scatter, result=[1:4:9, 2:4:10, 3:4:11, 4:4:12])
+            @test test_chunks(; array_length=15, nchunks=4, type=:scatter, result=[1:4:13, 2:4:14, 3:4:15, 4:4:12])
+            @test test_sum(; array_length=1, nchunks=1, type=:scatter)
+            @test test_sum(; array_length=2, nchunks=1, type=:scatter)
+            @test test_sum(; array_length=2, nchunks=2, type=:scatter)
+            @test test_sum(; array_length=3, nchunks=2, type=:scatter)
+            @test test_sum(; array_length=7, nchunks=3, type=:scatter)
+            @test test_sum(; array_length=12, nchunks=4, type=:scatter)
+            @test test_sum(; array_length=15, nchunks=4, type=:scatter)
+            @test test_sum(; array_length=117, nchunks=4, type=:scatter)
+            # test :batch chunks
+            @test test_chunks(; array_length=1, nchunks=1, type=:batch, result=[1:1])
+            @test test_chunks(; array_length=2, nchunks=1, type=:batch, result=[1:2])
+            @test test_chunks(; array_length=2, nchunks=2, type=:batch, result=[1:1, 2:2])
+            @test test_chunks(; array_length=3, nchunks=2, type=:batch, result=[1:2, 3:3])
+            @test test_chunks(; array_length=7, nchunks=3, type=:batch, result=[1:3, 4:5, 6:7])
+            @test test_chunks(; array_length=12, nchunks=4, type=:batch, result=[1:3, 4:6, 7:9, 10:12])
+            @test test_chunks(; array_length=15, nchunks=4, type=:batch, result=[1:4, 5:8, 9:12, 13:15])
+            @test test_sum(; array_length=1, nchunks=1, type=:batch)
+            @test test_sum(; array_length=2, nchunks=1, type=:batch)
+            @test test_sum(; array_length=2, nchunks=2, type=:batch)
+            @test test_sum(; array_length=3, nchunks=2, type=:batch)
+            @test test_sum(; array_length=7, nchunks=3, type=:batch)
+            @test test_sum(; array_length=12, nchunks=4, type=:batch)
+            @test test_sum(; array_length=15, nchunks=4, type=:batch)
+            @test test_sum(; array_length=117, nchunks=4, type=:batch)
+        end
+
+        @testset "traits overriding defaults" begin
+            iters = [
+                firstrest(1:10),
+                takestrict(1:10, 5),
+                repeatedly(() -> 1, 10),
+                distinct([5, 2, 2, 1, 2, 1, 1, 2, 4, 2]),
+                partition(take(countfrom(1), 6), 2),
+                groupby(x -> x[1], [(1, 2), (3, 4), (1, 4)]),
+                imap(+, [1, 2, 3], [3, 2, 1]),
+                subsets([:a, :b, :c]),
+                iterated(sin, 3),
+                nth(1:3, 2),
+                takenth(1:10, 2),
+                peekiter(1:10),
+                ncycle(0:3, 3),
+                ivec(ones(3, 3)),
+                flagfirst(1:10),
+                takewhile(x -> x^2 < 10, 1:10),
+                properties(1 + 2im),
+                propertyvalues(1 + 2im),
+                fieldvalues(1 + 2im)
+            ]
+            for iter in iters
+                @test IteratorSize(iter) == IteratorSize(typeof(iter))
+                # indirect way to test the same thing, through generators
+                g = (x for x in iter)
+                @test IteratorSize(g) == IteratorSize(iter)
+                @test IteratorSize(typeof(g)) == IteratorSize(typeof(iter))
             end
         end
     end
-
-    @testset "nth" begin
-        @testset for xs in Any[
-            [1, 2, 3],
-            1:3,
-            reshape(1:3, 3, 1),
-            sparse(reshape(1:3, 1, 3)),
-        ]
-            @test nth(xs, 3) == 3
-            @test_throws BoundsError nth(xs, 0)
-            @test_throws BoundsError nth(xs, 4)
-        end
-
-        @testset for xs in Any[take(1:3, 3), drop(-1:3, 2)]
-            @test nth(xs, 3) == 3
-            @test_throws BoundsError nth(xs, 0)
-        end
-
-        s = subsets([1, 2, 3])
-        @test_throws BoundsError nth(s, 0)
-        @test_throws BoundsError nth(s, length(s) + 1)
-
-        # #100
-        @test nth(drop(repeatedly(() -> 1), 1), 1) == 1
-    end
-
-
-    @testset "takenth" begin
-        tn0 = takenth(Any[], 10)
-        @test eltype(tn0) == Any
-        @test collect(tn0) == Any[]
-
-        tn1 = takenth(Int[], 10)
-        @test eltype(tn1) == Int
-        @test collect(tn1) == Int[]
-
-        @test_throws ArgumentError takenth([], 0)
-
-        tn2 = takenth(10:20, 3)
-        @test eltype(tn2) == Int
-        @test collect(tn2) == [12,15,18]
-
-        tn3 = takenth(10:20, 1)
-        @test eltype(tn3) == Int
-        @test collect(tn3) == collect(10:20)
-    end
-
-
-    @testset "iterated" begin
-        times_called = Ref(0)
-
-        function iter_func(x)
-            times_called[] += 1
-            x + 1
-        end
-
-        itd = iterated(iter_func, 3)
-        @test IteratorSize(itd) isa IsInfinite
-        @test collect(take(itd, 4)) == 3:6
-        # the first item is just the seed so iter_func isn't called
-        @test times_called[] == 3
-    end
-
-
-    @testset "peekiter" begin
-        pi0 = peekiter(1:10)
-        @test IteratorEltype(pi0) isa HasEltype
-        @test eltype(pi0) == Int
-        @test collect(pi0) == collect(1:10)
-
-        pi1 = peekiter([])
-        @test IteratorEltype(pi1) isa HasEltype
-        @test eltype(pi1) == eltype([])
-        @test collect(pi1) == collect([])
-
-        it = peekiter([:a, :b, :c])
-        @test IteratorEltype(it) isa HasEltype
-        @test eltype(it) == Symbol
-        x, s = iterate(it)
-        @test x == :a
-        @test peek(it, s) == Some(:b)
-
-        @test iterate(peekiter([])) === nothing
-
-        it = peekiter(1:10)
-        x, s = iterate(it)
-        @test x == 1
-        @test peek(it, s) == Some(2)
-
-        it = peekiter(1:1)
-        x, s = iterate(it)
-        @test x == 1
-        @test peek(it, s) === nothing
-        @test iterate(it, s) === nothing
-    end
-
-    @testset "ivec" begin
-        irange = 1:12
-        vector = collect(irange)
-        @test collect(ivec(irange)) == vector
-        @test collect(ivec(vector)) == vector
-
-        matrix = reshape(vector, 3, 4)
-        @test collect(ivec(matrix)) == vector
-
-        ndarray = reshape(vector, 2, 2, 3)
-        @test collect(ivec(ndarray)) == vector
-    end
-
-    @testset "flagfirst" begin
-        v = rand(1:10, 20)
-        Tv = typeof(v)
-        ff = flagfirst(v)
-        Tff = typeof(ff)
-        @test IteratorEltype(Tff) ≡ IteratorEltype(v)
-        @test eltype(Tff) ≡ Tuple{Bool, eltype(v)}
-        @test collect(flagfirst(v)) ==
-            collect(zip(vcat([true], fill(false, length(v) - 1)), v))
-
-        @test collect(flagfirst(Int[])) == Tuple{Bool,Int}[]
-    end
-
-    @testset "takewhile" begin
-        @test collect(takewhile(x -> x^2 < 10, 1:10)) == Any[1, 2, 3]
-        @test collect(takewhile(x -> x^2 < 10, Iterators.countfrom(1))) == Any[1, 2, 3]
-        @test collect(takewhile(x -> x^2 < 10, 5:10)) == Any[]
-        @test collect(takewhile(x -> true, 5:10)) == collect(5:10)
-    end
-
-    @testset "properties" begin
-        p1 = properties(1 + 2im)
-        @test IteratorEltype(p1) isa HasEltype
-        @test eltype(p1) == Any
-        @test IteratorSize(p1) isa HasLength
-        @test length(p1) == 2
-        @test collect(p1) == Any[(:re, 1), (:im, 2)]
-
-        ntp = (a = "", b = 1, c = 2.0)
-        p2 = properties(ntp)
-        @test collect(p2) == Tuple.(collect(pairs(ntp)))
-
-         # HasLength used as an example no-field struct
-        p3 = properties(HasLength())
-        @test collect(p3) == Any[]
-    end
-
-    @testset "propertyvalues" begin
-        pv1 = propertyvalues(1 + 2im)
-        @test IteratorEltype(pv1) isa HasEltype
-        @test eltype(pv1) == Any
-        @test IteratorSize(pv1) isa HasLength
-        @test length(pv1) == 2
-        @test collect(pv1) == Any[1, 2]
-
-        tp = ("", 1, 2.0)
-        pv2 = propertyvalues(tp)
-
-        # getproperty for tuples wasn't introduced until 1.2
-        # https://github.com/JuliaLang/julia/pull/31324
-        @static if VERSION < v"1.2.0-DEV.460"
-            @test_broken collect(pv2) == collect(tp)
-        else
-            @test collect(pv2) == collect(tp)
-        end
-
-        # HasLength used as an example no-field struct
-        pv3 = propertyvalues(HasLength())
-        @test collect(pv3) == Any[]
-    end
-
-    @testset "fieldvalues" begin
-        fv1 = fieldvalues(1 + 2im)
-        @test IteratorEltype(fv1) isa HasEltype
-        @test eltype(fv1) == Any
-        @test IteratorSize(fv1) isa HasLength
-        @test length(fv1) == 2
-        @test collect(fv1) == Any[1, 2]
-
-        tp = ("", 1, 2.0)
-        fv2 = fieldvalues(tp)
-        @test collect(fv2) == collect(tp)
-
-        # HasLength used as an example no-field struct
-        fv3 = fieldvalues(HasLength())
-        @test collect(fv3) == Any[]
-    end
-
-    @testset "traits overriding defaults" begin
-        iters = [
-            firstrest(1:10),
-            takestrict(1:10, 5),
-            repeatedly(() -> 1, 10),
-            distinct([5, 2, 2, 1, 2, 1, 1, 2, 4, 2]),
-            partition(take(countfrom(1), 6), 2),
-            groupby(x -> x[1], [(1,2),(3,4),(1,4)]),
-            imap(+, [1,2,3], [3, 2, 1]),
-            subsets([:a, :b, :c]),
-            iterated(sin, 3),
-            nth(1:3, 2),
-            takenth(1:10, 2),
-            peekiter(1:10),
-            ncycle(0:3,3),
-            ivec(ones(3,3)),
-            flagfirst(1:10),
-            takewhile(x -> x^2 < 10, 1:10),
-            properties(1 + 2im),
-            propertyvalues(1 + 2im),
-            fieldvalues(1 + 2im)
-        ]
-        for iter in iters
-            @test IteratorSize(iter) == IteratorSize(typeof(iter))
-            # indirect way to test the same thing, through generators
-            g = (x for x in iter)
-            @test IteratorSize(g) == IteratorSize(iter)
-            @test IteratorSize(typeof(g)) == IteratorSize(typeof(iter))
-        end
-    end
-end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -551,7 +551,7 @@ include("testing_macros.jl")
             # test :scatter chunks
             @test test_chunks(; array_length=1, nchunks=1, chunk_type=:scatter, result=[1:1])
             @test test_chunks(; array_length=2, nchunks=1, chunk_type=:scatter, result=[1:2])
-            @test test_chunks(; array_length=2, nchunks=2, chunk_type=:scatter, result=[1:1, 2:2])
+            @test test_chunks(; array_length=2, nchunks=2, chunk_type=:scatter, result=[1:2:1, 2:2:2])
             @test test_chunks(; array_length=3, nchunks=2, chunk_type=:scatter, result=[1:2:3, 2:2:2])
             @test test_chunks(; array_length=7, nchunks=3, chunk_type=:scatter, result=[1:3:7, 2:3:5, 3:3:6])
             @test test_chunks(; array_length=12, nchunks=4, chunk_type=:scatter, result=[1:4:9, 2:4:10, 3:4:11, 4:4:12])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -535,7 +535,9 @@ include("testing_macros.jl")
             end
             function sum_parallel(x, nchunks, chunk_type)
                 s = fill(zero(eltype(x)), nchunks)
-                Threads.@threads for (range, ichunk) in chunks(x, nchunks, chunk_type)
+                # Threading over the iterator fails in Julia 1.0
+                #Threads.@threads for (range, ichunk) in chunks(x, nchunks, chunk_type)
+                for (range, ichunk) in chunks(x, nchunks, chunk_type)
                     for i in range
                         s[ichunk] += x[i]
                     end


### PR DESCRIPTION
In this PR I implement the `chunks` iterator, which is useful to distribute the workload in threaded loops.

The iterators are implemented in this package, for the moment: https://github.com/m3g/ChunkSplitters.jl

The idea is to facilitate the distribution of workloads in custom threaded loops, with, for example:

```julia
julia> using IterTools

julia> Threads.@threads for (xrange, ichunk) in chunks(1:7, 3)
           @show xrange, ichunk
       end
(xrange, ichunk) = (6:7, 3)
(xrange, ichunk) = (4:5, 2)
(xrange, ichunk) = (1:3, 1)
```

and this can be used to split the workload in each range of indices of the array, and also to accumulate in thread-safe temporary variables, by indexing by the ranges and chunk numbers. For instance:

```julia
julia> function sum_parallel(f, x; nchunks=Threads.nthreads())
           s = fill(zero(eltype(x)), nchunks)
           Threads.@threads for (xrange, ichunk) in chunks(x, nchunks)
               for i in xrange
                   s[ichunk] += f(x[i])
               end
           end
           return sum(s)
       end
sum_parallel (generic function with 1 method)

julia> sum_parallel(x -> log(x)^7, rand(10^7); nchunks=128)
-5.039255477681504e10
```
