### PR TITLE
make BinomialIterState immutable

### DIFF
--- a/src/IterTools.jl
+++ b/src/IterTools.jl
@@ -539,7 +539,7 @@ IteratorEltype(::Type{Binomial{C}}) where {C} = IteratorEltype(C)
 
 subsets(xs, k) = Binomial(xs, length(xs), k)
 
-mutable struct BinomialIterState
+struct BinomialIterState
     idx::Vector{Int64}
     done::Bool
 end
@@ -564,9 +564,7 @@ function iterate(it::Binomial, state=BinomialIterState(collect(Int64, 1:it.k), i
         end
     end
 
-    state.done = i == 0
-
-    return set, state
+    return set, BinomialIterState(idx, i == 0)
 end
 
 


### PR DESCRIPTION
This is a trivial change that turns BinomialIterState into a regular, instead of a `mutable`, `struct`. It doesn't seem like there's any reason for the type to be mutable.