### PR TITLE
Add cached iterator

### DIFF
--- a/src/IterTools.jl
+++ b/src/IterTools.jl
@@ -32,6 +32,7 @@ export
     propertyvalues,
     fieldvalues,
     interleaveby
+    cache
 
 function has_length(it)
     it_size = IteratorSize(it)
@@ -1033,23 +1034,44 @@ function iterate(fs::FieldValues, state=1)
 
     return (getfield(fs.x, state), state + 1)
 end
-										
+
+# CachedIterator
+
 mutable struct CachedIterator{IT, EL}
     const it::IT
     const cache::Vector{EL}
     state
-    function CachedIterator(it::IT) where IT
-        EL = eltype(IT)
-        new{IT, EL}(it, Vector{EL}(), nothing)
-    end
 end
-Base.IteratorSize(::Type{CachedIterator{IT, EL}}) where {IT, EL} = Base.IteratorSize(IT)
-Base.IteratorEltype(::Type{CachedIterator{IT, EL}}) where {IT, EL} = Base.IteratorEltype(IT)
-Base.length(itr::CachedIterator) = length(itr.it)
-Base.size(itr::CachedIterator) = size(itr.it)
-Base.eltype(itr::CachedIterator{IT, EL}) where {IT, EL} = EL
 
-function Base.iterate(itr::CachedIterator, state=1)
+"""
+    cache(it)
+
+Cache the elements of an iterator so that subsequent iterations are served from the cache.
+
+```jldoctest
+julia> c = cache(Iterators.map(println, 1:3));
+
+julia> collect(c);
+1
+2
+3
+
+julia> collect(c);
+
+```
+"""
+function cache(it::IT) where IT
+    EL = eltype(IT)
+    CachedIterator{IT, EL}(it, Vector{EL}(), nothing)
+end
+
+IteratorSize(::Type{CachedIterator{IT, EL}}) where {IT, EL} = IteratorSize(IT)
+IteratorEltype(::Type{CachedIterator{IT, EL}}) where {IT, EL} = IteratorEltype(IT)
+length(itr::CachedIterator) = length(itr.it)
+size(itr::CachedIterator) = size(itr.it)
+eltype(::Type{CachedIterator{IT, EL}}) where {IT, EL} = EL
+
+function iterate(itr::CachedIterator, state=1)
     if state > length(itr.cache)
         if itr.state === nothing
             x = iterate(itr.it)

--- a/src/IterTools.jl
+++ b/src/IterTools.jl
@@ -1059,6 +1059,8 @@ julia> collect(c);
 julia> collect(c);
 
 ```
+Be aware that if iterating the original  has a side-effect it will not be repeated when iterating again,  -- indeed that is a key feature of the `CachedIterator`.
+Be aware also that if the original iterator is nondeterminatistic in its order, when iterating again from the cache it will infact be determinatistic and will be the same order as before -- this also is a feature.
 """
 function cache(it::IT) where IT
     EL = eltype(IT)

--- a/src/IterTools.jl
+++ b/src/IterTools.jl
@@ -31,7 +31,7 @@ export
     properties,
     propertyvalues,
     fieldvalues,
-    interleaveby
+    interleaveby,
     cache
 
 function has_length(it)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -537,16 +537,21 @@ include("testing_macros.jl")
     end
 
     @testset "CachedIterator" begin
-        invocations = 0
-        function f(x)
-            invocations += 1
-            return x
-        end
+        # Check basic behavour
         it = cache(1:10)
         @test IteratorEltype(it) isa HasEltype
         @test eltype(it) == Int
         @test IteratorSize(it) isa HasShape
         @test length(it) == 10
+        @test collect(it) == 1:10
+        @test collect(it) == 1:10
+
+        # Check actually not invoking multiple times
+        invocations = 0
+        function f(x)
+            invocations += 1
+            return x
+        end
         it = cache(Iterators.map(f, 1:10))
         @test isempty(it.cache)
         @test collect(it) == collect(1:10)
@@ -554,6 +559,11 @@ include("testing_macros.jl")
         @test invocations == 10
         @test collect(it) == collect(1:10)
         @test invocations == 10
+
+        # Check works with more complex iterators
+        it = cache(Iterators.zip(1:4, "abcd"))
+        @test collect(it) == [(1, 'a'), (2, 'b'), (3, 'c'), (4, 'd')]
+        @test collect(it) == [(1, 'a'), (2, 'b'), (3, 'c'), (4, 'd')]
     end
 
     @testset "traits overriding defaults" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -536,6 +536,26 @@ include("testing_macros.jl")
         @test collect(itr_mixed) == [1, 2, 'a', 'b', 'c', 'd']
     end
 
+    @testset "CachedIterator" begin
+        invocations = 0
+        function f(x)
+            invocations += 1
+            return x
+        end
+        it = cache(1:10)
+        @test IteratorEltype(it) isa HasEltype
+        @test eltype(it) == Int
+        @test IteratorSize(it) isa HasShape
+        @test length(it) == 10
+        it = cache(Iterators.map(f, 1:10))
+        @test isempty(it.cache)
+        @test collect(it) == collect(1:10)
+        @test it.cache == collect(1:10)
+        @test invocations == 10
+        @test collect(it) == collect(1:10)
+        @test invocations == 10
+    end
+
     @testset "traits overriding defaults" begin
         iters = [
             firstrest(1:10),


### PR DESCRIPTION
For iterators that are expensive to compute and cheap to store, you might want to cache the result so the next time you iterate it just returns items from the cache. In a way this is kind of like lazy sequences from Clojure/Lazy.jl

This is missing documentation and tests but would like to gauge interest before committing time to that.