### PR TITLE
docs: add an index and move the docstrings to a reference page

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -4,7 +4,8 @@ makedocs(
     modules = [IterTools],
     sitename = "IterTools",
     pages = [
-        "Docs" => "index.md",
+        "Home" => "index.md",
+        "API Reference" => "reference.md"
         ],
     doctest=false,
    )

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -10,7 +10,7 @@ end
 
 Install this package with `Pkg.add("IterTools")`
 
-# Usage
-```@autodocs
+## Index
+```@index
 Modules = [IterTools]
 ```

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -1,0 +1,5 @@
+# API Reference
+
+```@autodocs
+Modules = [IterTools]
+```


### PR DESCRIPTION
One disadvantage of [using Autodocs now](https://github.com/JuliaCollections/IterTools.jl/pull/107/files) is that the nice, easy-to-navigate list of names in the left sidebar that's in the [stable docs](https://juliacollections.github.io/IterTools.jl/stable/), is no longer there in the [dev docs](https://juliacollections.github.io/IterTools.jl/dev/). 

This PR uses Documenter's `@index` feature to generate an index of names as a replacement. I also moved the (`@autodoc`-ed) docstrings to a separate reference page, since it looks nicer to have just a quick list of functions at a glance in the homepage, instead of showing the intimidating full listing of docstrings right away.  