### PR TITLE
docs: fix README: update dev docs link & logo, and CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # IterTools.jl
 
-[![Build Status](https://travis-ci.org/JuliaCollections/IterTools.jl.svg?branch=master)](https://travis-ci.org/JuliaCollections/IterTools.jl)
+[![Build Status](https://github.com/JuliaCollections/IterTools.jl/actions/workflows/CI.yml/badge.svg?branch=master)](https://github.com/JuliaCollections/IterTools.jl/actions/workflows/CI.yml?query=branch%3Amaster)
 [![Coverage Status](https://codecov.io/gh/JuliaCollections/IterTools.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/JuliaCollections/IterTools.jl)
 [![Documentation (Stable)](https://img.shields.io/badge/docs-stable-blue.svg)](https://juliacollections.github.io/IterTools.jl/stable)
-[![Documentation (Latest)](https://img.shields.io/badge/docs-latest-blue.svg)](https://juliacollections.github.io/IterTools.jl/latest)
+[![Documentation (Development version)](https://img.shields.io/badge/docs-dev-blue.svg)](https://juliacollections.github.io/IterTools.jl/dev/)
 
-Common functional iterator patterns (formerly Iterators.jl).
+Common functional iterator patterns.
 
 ## Installation
 


### PR DESCRIPTION
Also remove reference to (now ancient) "Iterators.jl" name which is more likely to confuse than help users at this point.