### PR TITLE
Fix doctests and upgrade to Documenter v1 

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -2,4 +2,4 @@
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 
 [compat]
-Documenter = "0.27"
+Documenter = "1.0"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,12 +1,13 @@
 using Documenter, IterTools
 
+DocMeta.setdocmeta!(IterTools, :DocTestSetup, :(using IterTools))
 makedocs(
     modules = [IterTools],
     sitename = "IterTools",
     pages = [
         "Docs" => "index.md",
         ],
-    doctest=false,
+    doctest=true,
    )
 
 deploydocs(

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,9 +1,3 @@
-```@meta
-DocTestSetup = quote
-    using IterTools
-end
-```
-
 # IterTools
 
 ## Installation

--- a/src/IterTools.jl
+++ b/src/IterTools.jl
@@ -1106,12 +1106,12 @@ Input:
 ```jldoctest
 julia> collect(interleaveby(1:2:5, 2:2:6))
 6-element Vector{Int64}:
-  1
-  2
-  3
-  4
-  5
-  6
+ 1
+ 2
+ 3
+ 4
+ 5
+ 6
 ```
 
 If the predicate is `Base.isless` (the default) and both inputs are sorted, this produces the sorted output.
@@ -1215,6 +1215,25 @@ _zip_longest_promote_shape(a, b) = promote_shape(a, b)
 For one or more iterable objects, return an iterable of tuples, where the `i`th tuple
 contains the `i`th component of each input iterable if it is not finished, and `default`
 otherwise. `default` can be a scalar, or a tuple with one default per iterable.
+
+```jldoctest
+julia> for t in zip_longest(1:2, 5:8)
+         @show t
+       end
+t = (1, 5)
+t = (2, 6)
+t = (nothing, 7)
+t = (nothing, 8)
+
+julia> for t in zip_longest('a':'e', ['m', 'n']; default='x')
+         @show t
+       end
+t = ('a', 'm')
+t = ('b', 'n')
+t = ('c', 'x')
+t = ('d', 'x')
+t = ('e', 'x')
+```
 """
 zip_longest(its...; default=nothing) = ZipLongest(Tuple(_Padded.(its, default)))
 


### PR DESCRIPTION
Use `setdocmeta!` as is [required](https://documenter.juliadocs.org/stable/man/doctests/#Module-level-metadata) for docstring doctests, and remove the unnecessary `@meta` block. 

Fix minor spacing error in `interleaveby` doctest. 

Add doctest for `zip_longest`. 

Upgrade Documenter to version 1.

