### PR TITLE
docs: add a package Description and a See Also section

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -4,7 +4,18 @@
 
 Install this package with `Pkg.add("IterTools")`
 
+## Description
+
+Common functional iterator patterns.
+
+This package provides tools for working with iterators, in addition to those provided by `Base.Iterators`. It is lightweight and has no dependencies.
+
 ## Index
 ```@index
 Modules = [IterTools]
 ```
+
+## See also
+
+* [`Base.Iterators`](https://docs.julialang.org/en/v1/base/iterators/) is included with Julia
+* [SplitApplyCombine.jl](https://github.com/JuliaData/SplitApplyCombine.jl) has "tools [that] come in the form of high-level functions that operate on iterable or indexable containers in an intuitive and simple way"


### PR DESCRIPTION
Now that some space is [cleared up](https://github.com/JuliaCollections/IterTools.jl/pull/113) in the doc homepage, this PR adds a small description of the package and a "See also" section. 
