### PR TITLE
make `firstrest` an alias for `Iterators.peel`

### DIFF
--- a/src/IterTools.jl
+++ b/src/IterTools.jl
@@ -128,11 +128,9 @@ julia> collect(r)
 ```
 """
 function firstrest(xs)
-    t = iterate(xs)
+    t = Iterators.peel(xs)
     t === nothing && throw(ArgumentError("collection must be non-empty"))
-    f, s = t
-    r = Iterators.rest(xs, s)
-    return f, r
+    return t
 end
 
 # Iterate through the first n elements, throwing an exception if

--- a/src/IterTools.jl
+++ b/src/IterTools.jl
@@ -128,6 +128,7 @@ julia> collect(r)
 ```
 """
 function firstrest(xs)
+    Base.depwarn("`firstrest` is deprecated in favor of `Iterators.peel`", :firstrest)
     t = Iterators.peel(xs)
     t === nothing && throw(ArgumentError("collection must be non-empty"))
     return t

--- a/src/IterTools.jl
+++ b/src/IterTools.jl
@@ -113,7 +113,7 @@ end
 
 Return the first element and an iterator of the rest as a tuple.
 
-See also: `Base.Iterators.peel`.
+Alias for `Base.Iterators.peel`.
 
 ```jldoctest
 julia> f, r = firstrest(1:3);
@@ -127,12 +127,7 @@ julia> collect(r)
  3
 ```
 """
-function firstrest(xs)
-    Base.depwarn("`firstrest` is deprecated in favor of `Iterators.peel`", :firstrest)
-    t = Iterators.peel(xs)
-    t === nothing && throw(ArgumentError("collection must be non-empty"))
-    return t
-end
+const firstrest = Iterators.peel
 
 # Iterate through the first n elements, throwing an exception if
 # fewer than n items ar encountered.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,7 +36,7 @@ include("testing_macros.jl")
         ]
 
         @testset "$xs" for (xs, s) in test_empty_cases
-            @test_throws ArgumentError firstrest(xs)
+            @test nothing === firstrest(xs)
         end
     end
 


### PR DESCRIPTION
`Iterators.peel` is supported on all Julia versions supported by IterTools. In fact, it was already present with Julia v0.7.

Make `firstrest` an alias for `Iterators.peel`. This is a feature addition, making `firstrest` return `nothing` instead of throwing for an empty iterator input.